### PR TITLE
refactor: Simply makefiles

### DIFF
--- a/.mage/go.mod
+++ b/.mage/go.mod
@@ -2,7 +2,7 @@ module github.com/einride/mage-tools/.mage
 
 go 1.17
 
-require github.com/einride/mage-tools v0.0.0-20211029133512-38197f785fd2
+require github.com/einride/mage-tools v0.0.0-20211101160420-5dddc584a6f7
 
 require (
 	github.com/google/uuid v1.3.0 // indirect

--- a/.mage/go.sum
+++ b/.mage/go.sum
@@ -1,6 +1,8 @@
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/einride/mage-tools v0.0.0-20211101160420-5dddc584a6f7 h1:s2s+xTO1E00kgi52JDkOrCJXhY5FeAfXTzJOLCbDa4I=
+github.com/einride/mage-tools v0.0.0-20211101160420-5dddc584a6f7/go.mod h1:9gaP7fwUxQ7/Ac3OqDX3L10RPHH8GXlYqad0mplm5H4=
 github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-playground/locales v0.14.0/go.mod h1:sawfccIbzZTqEDETgFXqTho0QybSa7l++s0DH+LDiLs=
 github.com/go-playground/universal-translator v0.18.0/go.mod h1:UvRDBj+xPUEGrFYl+lu/H90nyDXpg0fqeB/AQUGNTVA=

--- a/Makefile
+++ b/Makefile
@@ -1,26 +1,19 @@
 .PHONY: all
-all: $(mage_version_lock)
+all: $(mage_target)
 
 mage_folder := $(abspath $(dir $(lastword $(MAKEFILE_LIST)))/.mage)
 mage_gen := $(mage_folder)/gen
-mage_tools = $(shell cd $(mage_folder) && go list -m -f '{{ .Version }}' github.com/einride/mage-tools)
-magefile = $(shell md5sum $(mage_folder)/magefile.go)
-mage_version_lock = $(mage_gen)/$(mage_tools)-$(magefile)
 mage_target := $(mage_gen)/targets.mk
-mage := go run mage.go
+mage := $(mage_gen)/local_mage
 
 include $(mage_target)
 
-# The lockfile is a combination of the mage-tool version and magefile md5sum
-# to support regeneration when mage-tools are bumped or magefile is changed.
-$(mage_version_lock):
-	$(info [$@] generating version lock file)
-	@git clean $(mage_folder)/ -fdx
-	@mkdir -p $(mage_gen)
-	@touch $(mage_version_lock)
-
-$(mage_target): $(mage_version_lock)
+$(mage_target): $(mage_folder)/go.mod $(mage_folder)/magefile.go
 	$(info [$@] generating targets...)
+	@git clean $(mage_gen)/ -fdx
+	@mkdir -p $(mage_gen)
 	@cd $(mage_folder) && \
 		go mod tidy && \
+		go run mage.go -compile $(mage) && \
 		$(mage) generateMakefile $(@)
+

--- a/make/makefile.go
+++ b/make/makefile.go
@@ -30,16 +30,6 @@ func GenerateMakefile(makefile string) error {
 
 	defer f.Close()
 
-	// This part will be written to the start of the makefile
-	t, _ := template.New("statc").Parse(
-		`make_dir := $(abspath $(dir $(firstword $(MAKEFILE_LIST))))
-`,
-	)
-	err = t.Execute(f, "")
-	if err != nil {
-		return err
-	}
-
 	for _, target := range targets {
 		parts := strings.Fields(target)
 		target := templateTargets{
@@ -47,13 +37,13 @@ func GenerateMakefile(makefile string) error {
 			MageTarget: target,
 			Args:       toMakeVars(parts[1:]),
 		}
-		t, _ = template.New("dynamic").Parse(`
+		t, _ := template.New("dynamic").Parse(`
 .PHONY: {{.MakeTarget}}
 {{.MakeTarget}}:{{range .Args}}
 ifndef {{.}}
 {{"\t"}}$(error missing argument {{.}}="...")
 endif{{end}}
-{{"\t"}}@cd $(mage_folder) && $(mage) -w $(make_dir) {{.MageTarget}}
+{{"\t"}}@$(mage) {{.MageTarget}}
 `)
 		err = t.Execute(f, target)
 		if err != nil {


### PR DESCRIPTION
This PR: 
- removes unnecessary dependencies for the make target.
- opts for compiling a binary to make the generated makefile also simpler, no cd and setting workdir needed

-------

old generated formatt:
```make
make_dir := $(abspath $(dir $(firstword $(MAKEFILE_LIST))))

.PHONY: golangci-lint
golangci-lint:
	@cd $(mage_folder) && $(mage) -w $(make_dir) golangciLint
```

new generated format:
```make
.PHONY: golangci-lint
golangci-lint:
	@$(mage) golangciLint
```

