### PR TITLE
feat: introduce terraform tool

### DIFF
--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -1,0 +1,47 @@
+package sgterraform
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"go.einride.tech/sage/sg"
+	"go.einride.tech/sage/sgtool"
+)
+
+const (
+	version    = "1.1.4"
+	binaryName = "terraform"
+)
+
+func Command(ctx context.Context, args ...string) *exec.Cmd {
+	return sg.Command(ctx, sg.FromBinDir(binaryName), args...)
+}
+
+func PrepareCommand(ctx context.Context) error {
+	hostOS := runtime.GOOS
+	hostArch := runtime.GOARCH
+	binaryDir := sg.FromBinDir(binaryName)
+	binary := filepath.Join(binaryDir, binaryName)
+	terraform := fmt.Sprintf("terraform_%s_%s_%s", version, hostOS, hostArch)
+	binURL := fmt.Sprintf(
+		"https://releases.hashicorp.com/terraform/%s/%s.zip",
+		version,
+		terraform,
+	)
+	if err := sgtool.FromRemote(
+		ctx,
+		binURL,
+		sgtool.WithDestinationDir(binaryDir),
+		sgtool.WithUnzip(),
+		sgtool.WithRenameFile(fmt.Sprintf("%s/terraform", terraform), binaryName),
+		sgtool.WithSkipIfFileExists(binary),
+		sgtool.WithSymlink(binary),
+	); err != nil {
+		return fmt.Errorf("unable to download %s: %w", binaryName, err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
It is unclear to me whether the `PrepareCommand(context.Context)` function fulfills any purpuse that is not clear in the API (Does not seem to be used anywhere so why is it public? Do we intend for users to be able to use it directly?) so I kept it here for consistency with the other packages.
