### PR TITLE
fix: revert "fix: cleanup the clean target"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ $(sagefile): .sage/go.mod $(shell find .sage/.. -type f -name '*.go')
 
 .PHONY: clean-sage
 clean-sage:
-	@git clean -fdx .sage
+	@git clean -fdx .sage/tools .sage/bin
 
 .PHONY: all
 all: $(sagefile)

--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -42,7 +42,7 @@ func generateMakefile(g *codegen.File, pkg *doc.Package, mk Makefile, mks ...Mak
 	g.P()
 	g.P(".PHONY: clean-sage")
 	g.P("clean-sage:")
-	g.P("\t@git clean -fdx ", includePath)
+	g.P("\t@git clean -fdx ", filepath.Join(includePath, ToolsDir), " ", filepath.Join(includePath, BinDir))
 	forEachTargetFunction(pkg, func(function *doc.Func, namespace *doc.Type) bool {
 		if function.Recv == mk.namespaceName() {
 			g.P()


### PR DESCRIPTION
This reverts commit 97aafa06a99fab1e849bb300c411a7c463339e65.

As @viktorvoltaire pointed out, if we clean at the `.mage` level, we
will "clean" away any work-in-progress sagefiles - that would not be
good!
