### PR TITLE
fix init file

### DIFF
--- a/sg/initfile.go
+++ b/sg/initfile.go
@@ -38,9 +38,11 @@ func generateInitFile(g *codegen.File, pkg *doc.Package) error {
 			expected := len(function.Decl.Type.Params.List)
 			g.P("if len(args) != ", expected, " {")
 			g.P(
-				`logger.Fatal("wrong number of arguments to %s, got %v expected %v",`,
+				`logger.Fatal("wrong number of arguments to %s, got %v expected %v", "`,
 				getTargetFunctionName(function),
+				`",`,
 				expected,
+				",",
 				`len(args))`,
 			)
 			g.P(g.Import("os"), ".Exit(1)")


### PR DESCRIPTION
- feat: migrate back from cmd to git root main
- chore: just run go run
- chore: use logger.Error instead of panic
- feat: prepend bin dir to sg.Command PATH
- feat(golangci-lint): run for all Go modules by default
- feat(sgtool): remove unused methods
- fix: remove outdated reference to cmd/build
- feat(yamlfmt): migrate to CLI tool
- feat: remove external dependencies
- feat(ghcomment): add tool
- feat(shfmt): add tool
- feat(gh): add tool
- fix: prepare command on terraform tool
- fix: wrong terraform binaryDir
- fix: clean-sage not removing bin folder
- chore: regenerate makefile
- fix: cleanup the clean target
- fix: revert "fix: cleanup the clean target"
- fix(initfile): fixes broken logger
