### PR TITLE
fix: ensure unique IDs for functions with different args

### DIFF
--- a/sg/deps.go
+++ b/sg/deps.go
@@ -29,7 +29,7 @@ func Deps(ctx context.Context, functions ...interface{}) {
 				}
 				wg.Done()
 			}()
-			errs[i] = runner.RunOnce(WithLogger(ctx, NewLogger(f.Name())), f.Name(), f.Run)
+			errs[i] = runner.RunOnce(WithLogger(ctx, NewLogger(f.Name())), f.ID(), f.Run)
 		}()
 	}
 	wg.Wait()


### PR DESCRIPTION
Regression from the mage-tools migration, fixed by introducing a unique
ID different from the display name.
