### PR TITLE
feat(sggit): use short hash when deriving version

### DIFF
--- a/tools/sggit/tools.go
+++ b/tools/sggit/tools.go
@@ -26,7 +26,7 @@ func VerifyNoDiff(ctx context.Context) error {
 
 func Version(ctx context.Context) string {
 	revision := sg.Output(
-		sg.Command(ctx, "git", "rev-parse", "--verify", "HEAD"),
+		sg.Command(ctx, "git", "rev-parse", "--verify", "--short", "HEAD"),
 	)
 	diff := sg.Output(
 		sg.Command(ctx, "git", "status", "--porcelain"),


### PR DESCRIPTION
The short hash is enough to derive the commit
