### PR TITLE
feat: add target for building sage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,12 @@
 
 sagefile := .sage/bin/sagefile
 
-$(sagefile): .sage/go.mod $(shell find .sage/.. -type f -name '*.go')
+.PHONY: $(sagefile)
+$(sagefile):
 	@cd .sage && go mod tidy && go run .
+
+.PHONY: sage
+sage: $(sagefile)
 
 .PHONY: clean-sage
 clean-sage:

--- a/sg/generate.go
+++ b/sg/generate.go
@@ -68,7 +68,7 @@ func GenerateMakefiles(mks ...Makefile) {
 		mk := codegen.NewMakefile(codegen.FileConfig{
 			GeneratedBy: "go.einride.tech/sage",
 		})
-		if err := generateMakefile(ctx, mk, pkg, v, mks...); err != nil {
+		if err := generateMakefile(mk, pkg, v, mks...); err != nil {
 			panic(err)
 		}
 		if err := os.WriteFile(v.Path, mk.RawContent(), 0o600); err != nil {


### PR DESCRIPTION
When migrating to sage in a repository yesterday I found that quite a lot of time I would go back into the sage directory to regenerate my Makefile. Adding a target for doing this could be useful.