### PR TITLE
exclude results from sage folder

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -53,7 +53,12 @@ func Run(ctx context.Context, args ...string) error {
 		if err != nil {
 			return err
 		}
-		cmd := Command(ctx, append([]string{"run", "-c", configPath, "--path-prefix", pathPrefix}, args...)...)
+		var excludeArg []string
+		if filepath.Dir(path) == sg.FromSageDir() {
+			excludeArg = append(excludeArg, "--exclude", "(is a global variable|is unused)")
+		}
+		cmdArgs := append([]string{"run", "-c", configPath, "--path-prefix", pathPrefix}, args...)
+		cmd := Command(ctx, append(cmdArgs, excludeArg...)...)
 		cmd.Dir = filepath.Dir(path)
 		commands = append(commands, cmd)
 		return cmd.Start()


### PR DESCRIPTION
Excludes certain results from the running golangcilint in .sage. Whats good is that this does not interfere with the anyone passing their own `--exclude` as args