### PR TITLE
feat: rename sg.Function to sg.Target

### DIFF
--- a/sg/deps.go
+++ b/sg/deps.go
@@ -12,7 +12,7 @@ import (
 
 // Deps runs each of the provided functions in parallel.
 //
-// Dependencies must be of type func(context.Context) error or Function.
+// Dependencies must be of type func(context.Context) error or Target.
 //
 // Each function will be run exactly once, even across multiple calls to Deps.
 func Deps(ctx context.Context, functions ...interface{}) {
@@ -52,10 +52,10 @@ func SerialDeps(ctx context.Context, targets ...interface{}) {
 	}
 }
 
-func checkFunctions(functions ...interface{}) []Function {
-	result := make([]Function, 0, len(functions))
+func checkFunctions(functions ...interface{}) []Target {
+	result := make([]Target, 0, len(functions))
 	for _, f := range functions {
-		if checked, ok := f.(Function); ok {
+		if checked, ok := f.(Target); ok {
 			result = append(result, checked)
 			continue
 		}

--- a/sg/fn.go
+++ b/sg/fn.go
@@ -8,20 +8,20 @@ import (
 	"runtime"
 )
 
-// Function represents a function that can be run with Deps.
-type Function interface {
-	// Name is a non-unique display name for the function.
+// Target represents a target function that can be run with Deps.
+type Target interface {
+	// Name is a non-unique display name for the Target.
 	Name() string
 
-	// ID is a unique identifier for the function.
+	// ID is a unique identifier for the Target.
 	ID() string
 
-	// Run the function.
+	// Run the Target.
 	Run(ctx context.Context) error
 }
 
-// Fn creates a Function from a compatible target function and args.
-func Fn(target interface{}, args ...interface{}) Function {
+// Fn creates a Target from a compatible function and args.
+func Fn(target interface{}, args ...interface{}) Target {
 	result, err := newFn(target, args...)
 	if err != nil {
 		panic(err)
@@ -29,7 +29,7 @@ func Fn(target interface{}, args ...interface{}) Function {
 	return result
 }
 
-func newFn(f interface{}, args ...interface{}) (Function, error) {
+func newFn(f interface{}, args ...interface{}) (Target, error) {
 	v := reflect.ValueOf(f)
 	if f == nil || v.Type().Kind() != reflect.Func {
 		return nil, fmt.Errorf("non-function passed to sg.Fn: %T", f)
@@ -106,17 +106,17 @@ type fn struct {
 	f    func(ctx context.Context) error
 }
 
-// ID implements Function.
+// ID implements Target.
 func (f fn) ID() string {
 	return f.id
 }
 
-// Name implements Function.
+// Name implements Target.
 func (f fn) Name() string {
 	return f.name
 }
 
-// Run implements Function.
+// Run implements Target.
 func (f fn) Run(ctx context.Context) error {
 	return f.f(ctx)
 }

--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -123,7 +123,7 @@ func toMakeVars(args []*ast.Field) []string {
 	return makeVars
 }
 
-// toSageFunction converts input to a sage Function name with the provided args.
+// toSageFunction converts input to a sage Target name with the provided args.
 func toSageFunction(target string, args []string) string {
 	for _, arg := range args {
 		arg = fmt.Sprintf("$(%s)", arg)


### PR DESCRIPTION
To add more specificity to the vocabulary (borrowing from Make
terminology) - it's hard to be specific when talking about "functions" -
it's easier to be specific when saying "Sage Targets" - because then you
know you are talking about a function that is meant to be run as a
target.
