### PR TITLE
chore(sggo): add explanation for the TestCommand

### DIFF
--- a/tools/sggo/tools.go
+++ b/tools/sggo/tools.go
@@ -9,6 +9,7 @@ import (
 	"go.einride.tech/sage/sg"
 )
 
+// TestCommand runs the default go test command and generates a coverage report.
 func TestCommand(ctx context.Context) *exec.Cmd {
 	coverFile := sg.FromBuildDir("go", "coverage", "go-test.txt")
 	if err := os.MkdirAll(filepath.Dir(coverFile), 0o755); err != nil {


### PR DESCRIPTION
This adds an explanation for the command and breaks out the
PrepareCommand parts of the command.