### PR TITLE
add protoc gen go grpc

### DIFF
--- a/sgtool/file.go
+++ b/sgtool/file.go
@@ -284,7 +284,7 @@ func (s *fileState) extractTar(reader io.Reader) error {
 
 		switch header.Typeflag {
 		case tar.TypeDir:
-			if err := os.Mkdir(path, 0o755); err != nil {
+			if err := os.MkdirAll(path, 0o755); err != nil {
 				return fmt.Errorf("extractTar: Mkdir() failed: %w", err)
 			}
 		case tar.TypeReg:

--- a/tools/sgprotocgengogrpc/tools.go
+++ b/tools/sgprotocgengogrpc/tools.go
@@ -1,0 +1,52 @@
+package sgprotocgengogrpc
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"go.einride.tech/sage/sg"
+	"go.einride.tech/sage/sgtool"
+)
+
+const (
+	version = "1.2.0"
+	name    = "protoc-gen-go-grpc"
+)
+
+func Command(ctx context.Context, args ...string) *exec.Cmd {
+	sg.Deps(ctx, PrepareCommand)
+	return sg.Command(ctx, sg.FromBinDir(name), args...)
+}
+
+func PrepareCommand(ctx context.Context) error {
+	binDir := sg.FromToolsDir(name, version)
+	binary := filepath.Join(binDir, name)
+	hostOS := runtime.GOOS
+	hostArch := runtime.GOARCH
+	
+	binURL := fmt.Sprintf(
+		"https://github.com/grpc/grpc-go/releases/download/cmd/protoc-gen-go-grpc/v%s/protoc-gen-go-grpc.v%s.%s.%s.tar.gz",
+		version,
+		version,
+		hostOS,
+		hostArch,
+	)
+	if err := sgtool.FromRemote(
+		ctx,
+		binURL,
+		sgtool.WithDestinationDir(binDir),
+		sgtool.WithUntarGz(),
+		sgtool.WithSkipIfFileExists(binary),
+		sgtool.WithSymlink(binary),
+	); err != nil {
+		return fmt.Errorf("unable to download %s: %w", name, err)
+	}
+	if err := os.Chmod(binary, 0o755); err != nil {
+		return fmt.Errorf("unable to make %s command: %w", name, err)
+	}
+	return nil
+}

--- a/tools/sgprotocgengogrpcserviceconfig/tools.go
+++ b/tools/sgprotocgengogrpcserviceconfig/tools.go
@@ -1,4 +1,4 @@
-package sgprotocgengogrpc
+package sgprotocgengogrpcserviceconfig
 
 import (
 	"context"


### PR DESCRIPTION
- feat: pipe stdout and err via logger
- fix: ensure single trailing newline for raw generated files
- feat: introduce build/ dir
- feat: generate .gitignore file
- fix: ensure unique IDs for functions with different args
- feat(sggit): use short hash when deriving version
- fix(init): expected number of arguments
- fix: correctly use fatalf instead of fatal
- fix: trim space for command output lines
- fix: prevent double-tagged logs
- fix: count repeated parameter names
- feat(deps): bump yamlfmt
- feat(initfile): remove namespace from logger
- feat: add target for building sage
- fix(sggit): show diff in error message
- feat(api-linter): add Run helper
- feat(protoc-gen-go-aip-test): add package
- feat(clang-format): add FormatProto helper
- fix(golangcilint): exclude certain results from .sage
- feat: rename sg.Function to sg.Target
- fix: remove leading newline from init message
- chore(sggo): add explanation for the TestCommand
- feat(npm-license): add a license-checker for npm
- feat(protobuf-gen-http): add a protobuf-http-generator
- chore(readme): add information on what happend when running make
- feat(tools): add protoc-gen-go-grpc-service-config
- feat(tools): add protoc-gen-go-grpc
- fix(protoc-gen-go-grpc-service-config): set correct package name
- fix(sgtool): use mkdirAll to avoid error when dir exist
