### PR TITLE
fix: use golang-migrate binary instead of go built version

### DIFF
--- a/tools/sggolangmigrate/tools.go
+++ b/tools/sggolangmigrate/tools.go
@@ -2,13 +2,19 @@ package sggolangmigrate
 
 import (
 	"context"
+	"fmt"
 	"os/exec"
+	"path/filepath"
+	"runtime"
 
 	"go.einride.tech/sage/sg"
 	"go.einride.tech/sage/sgtool"
 )
 
-const version = "v4.15.1"
+const (
+	version = "4.15.1"
+	name    = "migrate"
+)
 
 // nolint: gochecknoglobals
 var commandPath string
@@ -19,9 +25,25 @@ func Command(ctx context.Context, args ...string) *exec.Cmd {
 }
 
 func PrepareCommand(ctx context.Context) error {
-	binary, err := sgtool.GoInstall(ctx, "github.com/golang-migrate/migrate/v4/cmd/migrate", version)
-	if err != nil {
-		return err
+	binDir := sg.FromToolsDir(name, version)
+	binary := filepath.Join(binDir, name)
+	hostOS := runtime.GOOS
+	hostArch := runtime.GOARCH
+	fileName := fmt.Sprintf("migrate.%s-%s", hostOS, hostArch)
+	binURL := fmt.Sprintf(
+		"https://github.com/golang-migrate/migrate/releases/download/v%s/%s.tar.gz",
+		version,
+		fileName,
+	)
+	if err := sgtool.FromRemote(
+		ctx,
+		binURL,
+		sgtool.WithDestinationDir(binDir),
+		sgtool.WithUntarGz(),
+		sgtool.WithSkipIfFileExists(binary),
+		sgtool.WithSymlink(binary),
+	); err != nil {
+		return fmt.Errorf("unable to download %s: %w", binURL, err)
 	}
 	commandPath = binary
 	return nil


### PR DESCRIPTION
Building golang migrate requires some extra flags in order to include the spanner drivers so the current one is broken and besides that there is no reason to build it from Go since we don't have any dependencies on the library at runtime and it is generally faster to use the binary
