### PR TITLE
feat(protoc): support darwin/m1 for protoc

### DIFF
--- a/tools/sggrpcjava/tools.go
+++ b/tools/sggrpcjava/tools.go
@@ -44,6 +44,9 @@ func PrepareCommand(ctx context.Context) error {
 	if hostArch == sgtool.AMD64 {
 		hostArch = sgtool.X8664
 	}
+	if hostOS == "osx" && hostArch == "arm64" {
+		hostArch = sgtool.X8664
+	}
 	binURL := fmt.Sprintf(
 		"https://repo1.maven.org/maven2/io/grpc/%s/%s/%s-%s-%s-%s.exe",
 		binaryName,

--- a/tools/sgprotoc/tools.go
+++ b/tools/sgprotoc/tools.go
@@ -34,6 +34,9 @@ func PrepareCommand(ctx context.Context) error {
 	if hostArch == sgtool.AMD64 {
 		hostArch = sgtool.X8664
 	}
+	if hostOS == "osx" && hostArch == "arm64" {
+		hostArch = sgtool.X8664
+	}
 	binURL := fmt.Sprintf(
 		"https://github.com/protocolbuffers/protobuf/releases/download/v%s/protoc-%s-%s-%s.zip",
 		version,


### PR DESCRIPTION
This makes sure we download the x86 versions of the tools instead
of trying to download the missing arm64 versions.

For this to work it assumes that you have Rosetta 2 running.