### PR TITLE
feat: remove go dependency for every build step

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,7 @@ $(sagefile):
 	@cd .sage && go mod tidy && go run .
 
 .PHONY: sage
+sage: $(shell git clean -fxq $(sagefile))
 sage: $(sagefile)
 
 .PHONY: update-sage

--- a/sg/generate.go
+++ b/sg/generate.go
@@ -14,6 +14,7 @@ import (
 // GenerateMakefiles defines which Makefiles should be generated.
 func GenerateMakefiles(mks ...Makefile) {
 	ctx := WithLogger(context.Background(), NewLogger("sage"))
+	Logger(ctx).Println("building binary and generating Makefiles...")
 	if len(mks) == 0 {
 		panic("no makefiles to generate, see https://github.com/einride/sage#readme for more info")
 	}
@@ -67,7 +68,7 @@ func GenerateMakefiles(mks ...Makefile) {
 		mk := codegen.NewMakefile(codegen.FileConfig{
 			GeneratedBy: "go.einride.tech/sage",
 		})
-		if err := generateMakefile(mk, pkg, v, mks...); err != nil {
+		if err := generateMakefile(ctx, mk, pkg, v, mks...); err != nil {
 			panic(err)
 		}
 		if err := os.WriteFile(v.Path, mk.RawContent(), 0o600); err != nil {


### PR DESCRIPTION
Purpose:
Remove a go dependency for every build step in cloud build. 

Description:
With the 'old' setup, sage will require a dependency on 'go' for every buildstep in cloud-build. This gives more complexities than needed. Every non-go buildstep will need a image with both the desired language as well as go, as sage depends on this. For example if you want to build something with the node could-builder image, it will fail as it has a dependency on go. 

Solution:
The updated state will allow for non-go applications to first call `make sage` with a go based cloud-builder image, which will generate the binary sage file. And subsequently build the app with the desired default type of building images. 

 