### PR TITLE
feat(sggcloud): add GHA WIF auth helper

### DIFF
--- a/tools/sggcloud/tools.go
+++ b/tools/sggcloud/tools.go
@@ -1,0 +1,32 @@
+package sggcloud
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.einride.tech/sage/sg"
+)
+
+// GHACredentials generates short-lived credentials for GCP with workload identity federation.
+func GHACredentials(ctx context.Context, wifPoolName, serviceAccount string) string {
+	outputFile := filepath.Join(os.TempDir(), fmt.Sprintf("gha-creds-%s.json", strings.Split(wifPoolName, "/")[1]))
+	if _, err := os.Stat(outputFile); err == nil {
+		return outputFile
+	}
+	audienceURL := fmt.Sprintf("https://iam.googleapis.com/%s", wifPoolName)
+	if err := sg.Command(ctx, "gcloud", "iam", "workload-identity-pools", "create-cred-config",
+		wifPoolName,
+		"--service-account", serviceAccount,
+		"--output-file", outputFile,
+		"--credential-source-url", fmt.Sprintf("%s&audience=%s", os.Getenv("ACTIONS_ID_TOKEN_REQUEST_URL"), audienceURL),
+		"--credential-source-headers", fmt.Sprintf("Authorization=Bearer %s", os.Getenv("ACTIONS_ID_TOKEN_REQUEST_TOKEN")),
+		"--credential-source-type", "json",
+		"--credential-source-field-name", "value",
+	).Run(); err != nil {
+		panic(err)
+	}
+	return outputFile
+}


### PR DESCRIPTION
This introduces a replacement for handling auth in the actions pipeline, rather then having the below, one can now just use this function and pass the returned json file in the context with `sg.ContextWithEnv` to what ever command that needs it.
```yaml
    - id: 'auth'
        name: 'GCP Auth'
        uses: 'google-github-actions/auth@v0'
        with:
          workload_identity_provider: 'projects/PROJECT_NR/locations/global/workloadIdentityPools/github-actions/providers/github-actions'
          service_account: 'someServiceAccount@...'
```