### PR TITLE
feat: add support for namespace embedding

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,38 @@ func (Terraform) TerraformInitDev() {
 }
 ```
 
+It is also possible to embedded a Namespace in order to add metadata to it and potentially reuse it for different Makefiles
+
+```golang
+
+func main() {
+	sg.GenerateMakefiles(
+		sg.Makefile{
+			Path:          sg.FromGitRoot("Makefile"),
+			DefaultTarget: All,
+		},
+		sg.Makefile{
+			Path:          sg.FromGitRoot("names/name1/Makefile"),
+			Namespace:     MyNamespace{Name: "name1"},
+		},
+		sg.Makefile{
+			Path:          sg.FromGitRoot("names/name2/Makefile"),
+			Namespace:     MyNamespace{Name: "name2"},
+        },
+	)
+}
+
+
+type MyNamespace struct {
+	sg.Namespace
+	Name string
+}
+
+func (n MyNamespace) PrintName(ctx context.Context) error {
+	fmt.Println(n.Name)
+}
+```
+
 #### Dependencies
 
 Dependencies can be defined just by specificing the function, or with `sg.Fn` if the function takes arguments. `Deps` runs in parallel while `SerialDeps` runs serially.

--- a/sg/initfile.go
+++ b/sg/initfile.go
@@ -189,13 +189,29 @@ func isNamespace(t *doc.Type) bool {
 	if !ok {
 		return false
 	}
-	selectorExpr, ok := typeSpec.Type.(*ast.SelectorExpr)
+
+	// Is it embedded in a struct?
+	structType, ok := typeSpec.Type.(*ast.StructType)
+	if ok {
+		for _, f := range structType.Fields.List {
+			// Is it an embedded namespace
+			if f.Names == nil && isSelectorNamespaceType(f.Type) {
+				return true
+			}
+		}
+	}
+
+	return isSelectorNamespaceType(typeSpec.Type)
+}
+
+func isSelectorNamespaceType(expr ast.Expr) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
 	if !ok {
 		return false
 	}
-	ident, ok := selectorExpr.X.(*ast.Ident)
+	ident, ok := selector.X.(*ast.Ident)
 	if !ok {
 		return false
 	}
-	return ident.Name == "sg" && selectorExpr.Sel.Name == "Namespace"
+	return ident.Name == "sg" && selector.Sel.Name == "Namespace"
 }


### PR DESCRIPTION
I was trying to design a reusable namespace with sage and thought this might be something interesting to support.

The idea is to be able to do something like this

```go
package main

import "fmt"

type MyNamespace struct {
	sg.Namespace
	Name string
}

func (m MyNamespace) All(ctx context.Context) error {
	sg.SerialDeps(
		ctx,
		m.PrintName,
	)
	return nil
}

func (n MyNamespace) PrintName(ctx context.Context) error {
	fmt.Println(n.Name)
}
```

And then we can reuse the namespace to generate different makefiles

```go
func main() {
	sg.GenerateMakefiles(
		sg.Makefile{
			Path:          sg.FromGitRoot("Makefile"),
			DefaultTarget: All,
		},
		name1 := MyNamespace{Name: "name1"}
		sg.Makefile{
			Path:          sg.FromGitRoot("names/name1/Makefile"),
			DefaultTarget: name1.All,
			Namespace:     name1,
		},
		name2 := MyNamespace{Name: "name2"}
		sg.Makefile{
                        Path:          sg.FromGitRoot("names/name2/Makefile"),
                        DefaultTarget: name2.All,
                        Namespace:     name2,
                },
	)
}
```

The use case here was to design a repo which will contain folders with different applications each with their own makefile.
