### PR TITLE
Mac M1 support for protoc-gen-go-grpc 

### DIFF
--- a/sgtool/file.go
+++ b/sgtool/file.go
@@ -29,6 +29,10 @@ const (
 )
 
 const (
+	Darwin = "darwin"
+)
+
+const (
 	AMD64 = "amd64"
 	X8664 = "x86_64"
 )

--- a/tools/sgclangformat/tools.go
+++ b/tools/sgclangformat/tools.go
@@ -50,7 +50,7 @@ func PrepareCommand(ctx context.Context) error {
 	switch strings.Split(runtime.GOOS, "/")[0] {
 	case "linux":
 		osArch = "linux_x64"
-	case "darwin":
+	case sgtool.Darwin:
 		osArch = "darwin_x64"
 	default:
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)

--- a/tools/sgconvco/tools.go
+++ b/tools/sgconvco/tools.go
@@ -30,7 +30,7 @@ func PrepareCommand(ctx context.Context) error {
 	switch strings.Split(runtime.GOOS, "/")[0] {
 	case "linux":
 		hostOS = "ubuntu"
-	case "darwin":
+	case sgtool.Darwin:
 		hostOS = "macos"
 	default:
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)

--- a/tools/sggosemanticrelease/tools.go
+++ b/tools/sggosemanticrelease/tools.go
@@ -47,8 +47,8 @@ func PrepareCommand(ctx context.Context) error {
 	switch strings.Split(runtime.GOOS, "/")[0] {
 	case "linux":
 		hostOS = "linux"
-	case "darwin":
-		hostOS = "darwin"
+	case sgtool.Darwin:
+		hostOS = sgtool.Darwin
 	default:
 		return fmt.Errorf("unsupported OS: %s", runtime.GOOS)
 	}

--- a/tools/sggrpcjava/tools.go
+++ b/tools/sggrpcjava/tools.go
@@ -37,7 +37,7 @@ func PrepareCommand(ctx context.Context) error {
 		return fmt.Errorf("pom.xml is out of sync with gRPC Java version - expecting %s", version)
 	}
 	hostOS := runtime.GOOS
-	if hostOS == "darwin" {
+	if hostOS == sgtool.Darwin {
 		hostOS = "osx"
 	}
 	hostArch := runtime.GOARCH

--- a/tools/sgprotoc/tools.go
+++ b/tools/sgprotoc/tools.go
@@ -27,7 +27,7 @@ func PrepareCommand(ctx context.Context) error {
 	binDir := sg.FromToolsDir(binaryName, version)
 	binary := filepath.Join(binDir, "bin", binaryName)
 	hostOS := runtime.GOOS
-	if hostOS == "darwin" {
+	if hostOS == sgtool.Darwin {
 		hostOS = "osx"
 	}
 	hostArch := runtime.GOARCH

--- a/tools/sgprotocgengogrpc/tools.go
+++ b/tools/sgprotocgengogrpc/tools.go
@@ -27,7 +27,7 @@ func PrepareCommand(ctx context.Context) error {
 	binary := filepath.Join(binDir, name)
 	hostOS := runtime.GOOS
 	hostArch := runtime.GOARCH
-	if hostOS == "darwin" {
+	if hostOS == sgtool.Darwin {
 		hostArch = sgtool.AMD64
 	}
 	binURL := fmt.Sprintf(

--- a/tools/sgprotocgengogrpc/tools.go
+++ b/tools/sgprotocgengogrpc/tools.go
@@ -27,6 +27,9 @@ func PrepareCommand(ctx context.Context) error {
 	binary := filepath.Join(binDir, name)
 	hostOS := runtime.GOOS
 	hostArch := runtime.GOARCH
+	if hostOS == "darwin" {
+		hostArch = sgtool.AMD64
+	}
 	binURL := fmt.Sprintf(
 		"https://github.com/grpc/grpc-go/releases/download/cmd/protoc-gen-go-grpc/v%s/protoc-gen-go-grpc.v%s.%s.%s.tar.gz",
 		version,


### PR DESCRIPTION
- fix: mac m1 support for protocgengogrpc
- refactor: "darwin" string to constant
