### PR TITLE
fix(embedded-ns): reflect on values in embedded namesapce

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ func (Terraform) TerraformInitDev() {
 }
 ```
 
-It is also possible to embedded a Namespace in order to add metadata to it and potentially reuse it for different Makefiles
+It is also possible to embed a Namespace in order to add metadata to it and potentially reuse it for different Makefiles, the supported fields for an embedded Namespace are exported String, Int & Boolean.
 
 ```golang
 

--- a/sg/generate.go
+++ b/sg/generate.go
@@ -41,7 +41,7 @@ func GenerateMakefiles(mks ...Makefile) {
 		Package:     pkg.Name,
 		GeneratedBy: "go.einride.tech/sage",
 	})
-	if err := generateInitFile(initFile, pkg); err != nil {
+	if err := generateInitFile(initFile, pkg, mks); err != nil {
 		panic(err)
 	}
 	initFileContent, err := initFile.GoContent()


### PR DESCRIPTION
This PR partially fixes what was introduced in https://github.com/einride/sage/pull/198

I decided only to reflect String, Int and Bool. As any other types gets very hard and complex to template, I think these are fine to start with anyway and we can see where this feature takes us 