### PR TITLE
fix(sgtool): add space between url and dots to make it clickable

### DIFF
--- a/sgtool/file.go
+++ b/sgtool/file.go
@@ -71,7 +71,7 @@ func FromRemote(ctx context.Context, addr string, opts ...Opt) error {
 			return nil
 		}
 	}
-	sg.Logger(ctx).Printf("fetching %s...", addr)
+	sg.Logger(ctx).Printf("fetching %s ...", addr)
 	rStream, cleanup, err := s.downloadBinary(ctx, addr)
 	if err != nil {
 		return fmt.Errorf("unable to download file: %w", err)


### PR DESCRIPTION
To not get links like: [https://github.com/convco/convco/releases/download/v0.3.8/convco-ubuntu.zip...](https://github.com/convco/convco/releases/download/v0.3.8/convco-ubuntu.zip...)