### PR TITLE
fix: run target generation function for all functions

### DIFF
--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -85,7 +85,7 @@ func generateMakefile(ctx context.Context, g *codegen.File, pkg *doc.Package, mk
 		" ",
 		filepath.Join(includePath, buildDir),
 	)
-	forEachTargetFunction(pkg, func(function *doc.Func, namespace *doc.Type) bool {
+	forEachTargetFunction(pkg, func(function *doc.Func, namespace *doc.Type) {
 		if function.Recv == mk.namespaceName() {
 			g.P()
 			g.P(".PHONY: ", toMakeTarget(getTargetFunctionName(function)))
@@ -103,7 +103,6 @@ func generateMakefile(ctx context.Context, g *codegen.File, pkg *doc.Package, mk
 				toSageFunction(getTargetFunctionName(function), args),
 			)
 		}
-		return true
 	})
 	// Add additional makefiles to default makefile
 	if mk.namespaceName() == "" {


### PR DESCRIPTION
When one function was not eligible for generation, it was preventing all other functions from being evaluated in the package and namespaces.
The bool return wasn't doing much so instead we just run the function
