### PR TITLE
fix(api-linter): walk from git root instead of cwd

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -44,7 +44,7 @@ func Run(ctx context.Context, args ...string) error {
 		return err
 	}
 	var hasProblem bool
-	if err := filepath.WalkDir(sg.FromWorkDir(), func(path string, d fs.DirEntry, err error) error {
+	if err := filepath.WalkDir(sg.FromGitRoot(), func(path string, d fs.DirEntry, err error) error {
 		switch {
 		case err != nil:
 			return err


### PR DESCRIPTION
Works consistently regardless of which working dir it's called from.
