### PR TITLE
fix: use $(MAKE) for recursive make

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ $(sagefile):
 .PHONY: sage
 sage:
 	@git clean -fxq $(sagefile)
-	@make $(sagefile)
+	@$(MAKE) $(sagefile)
 
 .PHONY: update-sage
 update-sage:

--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -69,7 +69,7 @@ func generateMakefile(ctx context.Context, g *codegen.File, pkg *doc.Package, mk
 	g.P(".PHONY: sage")
 	g.P("sage:")
 	g.P("\t@git clean -fxq $(sagefile)")
-	g.P("\t@make $(sagefile)")
+	g.P("\t@$(MAKE) $(sagefile)")
 	g.P()
 	g.P(".PHONY: update-sage")
 	g.P("update-sage:")


### PR DESCRIPTION
https://www.gnu.org/software/make/manual/make.html#index-MAKE

> Recursive make commands should always use the variable MAKE, not the
> explicit command name ‘make’, as shown here:

```
subsystem:
        cd subdir && $(MAKE)
```
