### PR TITLE
feat: reusable namespaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,32 +43,32 @@ clean-sage:
 
 .PHONY: all
 all: $(sagefile)
-	@$(sagefile) All
+	@$(sagefile) "Target2901124887:All"
 
 .PHONY: convco-check
 convco-check: $(sagefile)
-	@$(sagefile) ConvcoCheck
+	@$(sagefile) "Target2901124887:ConvcoCheck"
 
 .PHONY: format-markdown
 format-markdown: $(sagefile)
-	@$(sagefile) FormatMarkdown
+	@$(sagefile) "Target2901124887:FormatMarkdown"
 
 .PHONY: git-verify-no-diff
 git-verify-no-diff: $(sagefile)
-	@$(sagefile) GitVerifyNoDiff
+	@$(sagefile) "Target2901124887:GitVerifyNoDiff"
 
 .PHONY: go-lint
 go-lint: $(sagefile)
-	@$(sagefile) GoLint
+	@$(sagefile) "Target2901124887:GoLint"
 
 .PHONY: go-mod-tidy
 go-mod-tidy: $(sagefile)
-	@$(sagefile) GoModTidy
+	@$(sagefile) "Target2901124887:GoModTidy"
 
 .PHONY: go-review
 go-review: $(sagefile)
-	@$(sagefile) GoReview
+	@$(sagefile) "Target2901124887:GoReview"
 
 .PHONY: go-test
 go-test: $(sagefile)
-	@$(sagefile) GoTest
+	@$(sagefile) "Target2901124887:GoTest"

--- a/sg/namespace.go
+++ b/sg/namespace.go
@@ -1,4 +1,88 @@
 package sg
 
+import (
+	"go/ast"
+	"go/doc"
+	"hash/fnv"
+	"strconv"
+)
+
 // Namespace allows for the grouping of similar commands.
 type Namespace struct{}
+
+func makefileNSPrefix(mk Makefile) string {
+	h := fnv.New32a()
+	h.Write([]byte(mk.Path))
+	return "Target" + strconv.Itoa(int(h.Sum32()))
+}
+
+func isNamespace(t *doc.Type) bool {
+	if len(t.Decl.Specs) != 1 {
+		return false
+	}
+	typeSpec, ok := t.Decl.Specs[0].(*ast.TypeSpec)
+	if !ok {
+		return false
+	}
+
+	// Is it embedded in a struct?
+	structType, ok := typeSpec.Type.(*ast.StructType)
+	if ok {
+		for _, f := range structType.Fields.List {
+			// Is it an embedded namespace
+			if f.Names == nil && isSelectorNamespaceType(f.Type) {
+				return true
+			}
+		}
+	}
+
+	return isSelectorNamespaceType(typeSpec.Type)
+}
+
+func isSelectorNamespaceType(expr ast.Expr) bool {
+	selector, ok := expr.(*ast.SelectorExpr)
+	if !ok {
+		return false
+	}
+	ident, ok := selector.X.(*ast.Ident)
+	if !ok {
+		return false
+	}
+	return ident.Name == "sg" && selector.Sel.Name == "Namespace"
+}
+
+func namespaceTargets(pkg *doc.Package, mk Makefile) []*doc.Func {
+	var fns []*doc.Func
+	// If no namespace is given then all package functions are elgible
+	// for target
+	if mk.namespaceName() == "" {
+		for _, fn := range pkg.Funcs {
+			if !isValidFunction(fn) {
+				continue
+			}
+			fns = append(fns, fn)
+		}
+	} else {
+		for _, ns := range pkg.Types {
+			ns := ns
+			if !isValidNamespace(ns) || ns.Name != mk.namespaceName() {
+				continue
+			}
+			for _, fn := range ns.Methods {
+				if !isValidFunction(fn) {
+					continue
+				}
+				fns = append(fns, fn)
+			}
+		}
+	}
+	return fns
+}
+
+func isValidNamespace(ns *doc.Type) bool {
+	return ast.IsExported(ns.Name) && isNamespace(ns)
+}
+
+func isValidFunction(fn *doc.Func) bool {
+	return ast.IsExported(fn.Name) && isSupportedTargetFunctionParams(fn.Decl.Type.Params.List)
+}


### PR DESCRIPTION
This PR adds support for reusing a namespace for more than 1 Makefile essentially allowing you do to the following

```go
type Terraform sg.Namespace

func (Terraform) Plan(ctx context.Context) error {
	// do terraform plan here
}

func main() {
	sg.GenerateMakefiles(
		sg.Makefile{
			Path:          sg.FromGitRoot("Makefile"),
			DefaultTarget: All,
		},
		sg.Makefile{
			Path:          sg.FromGitRoot("project1/Makefile"),
			Namespace:     Terraform{},
		},
		sg.Makefile{
			Path:          sg.FromGitRoot("project2/Makefile"),
			Namespace:     Terraform{},
		},
	)
}
```

Which would then generate a Makefile in folder `project1` and `project2` with the targets in the Terraform namespace

The main change here is that rather than 1 single init function in the generated sage binary, we now generate 1 function for each Makefile and use the hash of the defined Makefile path as a prefix to know which Makefile is calling the sage binary.

Together with this work I refactored the generation code and broke it out into a few isolated functions to try and make that code, which was getting difficult to work with, a little easier to understand.

There is one major user facing change and a minor one.

The major one is that the targets generated in the root Makefile for calling other Makefiles is now the path of the Makefile file directory rather than the namespace name. So before, for the example above, you would have `make terraform` as a target in the root Makefile and now you have `make project1` and `make project2` instead (which I think it makes sense from a point of view of make.

The minor one is that the sage binary call inside the make target would be slight more readable and now will contain the hashed prefix. So in the example above you would have

```Makefile
.PHONY: terraform-plan
terraform-plan: $(sagefile)
	@$(sagefile) Terraform:Plan
```

and now will look something like this

```Makefile
.PHONY: terraform-plan
terraform-plan: $(sagefile)
	@$(sagefile) "Target1692162558:Terraform:Plan"
```

