### PR TITLE
feat: bump golangci linter

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.44.2"
+	version = "1.45.0"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
This version includes support for Go 1.18 however it does so by disabling the following plugins


* bodyclose
* contextcheck
* gosimple
* nilerr
* noctx
* rowserrcheck
* sqlclosecheck
* staticcheck
* stylecheck
* tparallel
* unparam
* unused
* wastedassign

And requiring an extra config paramater in the config file which we do not include in this PR.

Since we are using many of these linters today, this PR is meant to allow users to bring their own local repo config with 1.18 support enabled if they so wish but keeping the 1.17 config for now
