### PR TITLE
feat: enable Go 1.18 on golangci-lint per default

### DIFF
--- a/sgtool/file.go
+++ b/sgtool/file.go
@@ -219,7 +219,6 @@ func (s *fileState) downloadBinary(ctx context.Context, url string) (io.ReadClos
 	}
 
 	req.Header = s.httpHeader
-	// nolint: bodyclose // false positive due to cleanup function
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("download binary %s: %w", url, err)

--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -1,6 +1,7 @@
 run:
   timeout: 10m
   allow-parallel-runners: true
+  go: 1.18
 
 issues:
   fix: true


### PR DESCRIPTION
This PR enables Go 1.18 support in GolangCI lint per default.

Draft until someone can verify it works as intended in Go 1.18

NOTE: GolangCI Lint removes the `bodyclose` comment for some reason