### PR TITLE
fix(golangci-lint): bump to v1.45.1

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.45.0"
+	version = "1.45.1"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
https://github.com/golangci/golangci-lint/releases/tag/v1.45.1

Includes automatic detection of Go version for example.