### PR TITLE
Revert "feat(deps): bump convco to 0.3.9"

### DIFF
--- a/tools/sgconvco/tools.go
+++ b/tools/sgconvco/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "convco"
-	version = "0.3.9"
+	version = "0.3.8"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
This reverts commit 44023c709b2ce6efc92f06326296037c5bb0989f.

Not statically linked against glibc dependency causes errors on Google
Cloud Build.
