### PR TITLE
feat(golangci-lint): expose default config

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -21,7 +21,7 @@ const (
 )
 
 //go:embed golangci.yml
-var defaultConfig []byte
+var DefaultConfig []byte
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
 	sg.Deps(ctx, PrepareCommand)
@@ -34,7 +34,7 @@ func Run(ctx context.Context, args ...string) error {
 	if err := os.MkdirAll(filepath.Dir(defaultConfigPath), 0o755); err != nil {
 		return err
 	}
-	if err := os.WriteFile(defaultConfigPath, defaultConfig, 0o600); err != nil {
+	if err := os.WriteFile(defaultConfigPath, DefaultConfig, 0o600); err != nil {
 		return err
 	}
 	var commands []*exec.Cmd


### PR DESCRIPTION
Expose the default golangci-lint config to be used by other projects who want to run the `Command()` but still want to benefit from the defaul configuration.
