### PR TITLE
bump versions w13

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.30.0"
+	version = "1.30.1"
 	name    = "api-linter"
 )
 

--- a/tools/sgbuf/tools.go
+++ b/tools/sgbuf/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "1.2.1"
+	version = "1.3.1"
 	name    = "buf"
 )
 

--- a/tools/sggh/tools.go
+++ b/tools/sggh/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "gh"
-	version = "2.6.0"
+	version = "2.7.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.45.1"
+	version = "1.45.2"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
- feat(buf): bump to v1.3.1
- feat(api-linter): bump to v1.30.1
- feat(gh): bump to v2.7.0
- feat(golangci-lint): bump to v1.45.2
