### PR TITLE
feat(protoc): keep include directory

### DIFF
--- a/tools/sgprotoc/tools.go
+++ b/tools/sgprotoc/tools.go
@@ -3,7 +3,6 @@ package sgprotoc
 import (
 	"context"
 	"fmt"
-	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
@@ -12,7 +11,7 @@ import (
 	"go.einride.tech/sage/sgtool"
 )
 
-const version = "3.15.7"
+const version = "3.20.1"
 
 // nolint: gochecknoglobals
 var commandPath string
@@ -53,9 +52,6 @@ func PrepareCommand(ctx context.Context) error {
 		sgtool.WithSymlink(binary),
 	); err != nil {
 		return fmt.Errorf("unable to download %s: %w", binaryName, err)
-	}
-	if err := os.RemoveAll(filepath.Join(binDir, "include")); err != nil {
-		return err
 	}
 	commandPath = binary
 	return nil


### PR DESCRIPTION
The include dir is useful since it allows you to compile protobuf files that reference for example `google/protobuf/timestamp.proto`. When removed we need to manually include these from elsewhere which is a bit of a hassle.

Also upgrade `protoc` to the latest version.

The include dir must be adjacent to the binary for protoc to pick up it btw, so can't really be moved elsewhere without altering the invocation flags.