### PR TITLE
chore(deps): bump terraform from 1.1.4 to 1.2.1

### DIFF
--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version    = "1.1.4"
+	version    = "1.2.1"
 	binaryName = "terraform"
 )
 


### PR DESCRIPTION
No breaking changes: https://github.com/hashicorp/terraform/blob/v1.2/CHANGELOG.md

The most exciting parts to me are:
- When showing a plan, Terraform CLI will now only show "Changes outside of Terraform" if they relate to resources and resource attributes that contributed to the changes Terraform is proposing to make.
- replace_triggered_by is a new lifecycle argument for managed resources which triggers replacement of an object based on changes to an upstream dependency.