### PR TITLE
feat(sqlc): fallback to x86_64 builds on Darwin ARM64

### DIFF
--- a/sgtool/file.go
+++ b/sgtool/file.go
@@ -35,6 +35,7 @@ const (
 const (
 	AMD64 = "amd64"
 	X8664 = "x86_64"
+	ARM64 = "arm64"
 )
 
 type Opt func(f *fileState)

--- a/tools/sggrpcjava/tools.go
+++ b/tools/sggrpcjava/tools.go
@@ -33,7 +33,7 @@ func PrepareCommand(ctx context.Context) error {
 	if hostArch == sgtool.AMD64 {
 		hostArch = sgtool.X8664
 	}
-	if hostOS == "osx" && hostArch == "arm64" {
+	if hostOS == "osx" && hostArch == sgtool.ARM64 {
 		hostArch = sgtool.X8664
 	}
 	binURL := fmt.Sprintf(

--- a/tools/sgprotoc/tools.go
+++ b/tools/sgprotoc/tools.go
@@ -34,7 +34,7 @@ func PrepareCommand(ctx context.Context) error {
 	if hostArch == sgtool.AMD64 {
 		hostArch = sgtool.X8664
 	}
-	if hostOS == "osx" && hostArch == "arm64" {
+	if hostOS == "osx" && hostArch == sgtool.ARM64 {
 		hostArch = sgtool.X8664
 	}
 	binURL := fmt.Sprintf(

--- a/tools/sgsqlc/tools.go
+++ b/tools/sgsqlc/tools.go
@@ -25,7 +25,11 @@ func PrepareCommand(ctx context.Context) error {
 	toolDir := sg.FromToolsDir(name, version)
 	binary := filepath.Join(toolDir, name)
 	arch := runtime.GOARCH
+	hostOS := runtime.GOOS
 	if arch == sgtool.X8664 {
+		arch = sgtool.AMD64
+	}
+	if hostOS == sgtool.Darwin && arch == sgtool.ARM64 {
 		arch = sgtool.AMD64
 	}
 	binURL := fmt.Sprintf(


### PR DESCRIPTION
Allows running sqlc on ARM64 Mac using Rosetta.