### PR TITLE
feat: bump golangci-lint to v1.47.0

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -10,7 +10,7 @@ inputs:
   go-version:
     description: The Go version to download (if necessary) and use. Supports semver spec and ranges.
     required: false
-    default: 1.17
+    default: 1.18
 
   fetch-depth:
     description: Number of commits to fetch. 0 indicates all history for all branches and tags.

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.46.2"
+	version = "1.47.0"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
- feat(golangcilint): bump to v1.47.0
- feat(setupsage): use Go 1.18 by default
