### PR TITLE
fix(sgconvco): revert to 0.3.8

### DIFF
--- a/tools/sgconvco/tools.go
+++ b/tools/sgconvco/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "convco"
-	version = "0.3.11"
+	version = "0.3.8"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
Still not statically linked against glibc, causing issues on Cloud
Build.
