### PR TITLE
feat(sgcloudendpoints): improve helpers

### DIFF
--- a/tools/sgcloudendpoints/Dockerfile
+++ b/tools/sgcloudendpoints/Dockerfile
@@ -1,9 +1,8 @@
-FROM gcr.io/endpoints-release/endpoints-runtime-serverless:2
-
+ARG esp_version=2
+FROM gcr.io/endpoints-release/endpoints-runtime-serverless:${esp_version}
 USER root
 ENV ENDPOINTS_SERVICE_PATH /etc/endpoints/service.json
 COPY ./service.json ${ENDPOINTS_SERVICE_PATH}
 RUN chown -R envoy:envoy ${ENDPOINTS_SERVICE_PATH} && chmod -R 755 ${ENDPOINTS_SERVICE_PATH}
 USER envoy
-
 ENTRYPOINT ["/env_start_proxy.py"]

--- a/tools/sgcloudendpoints/deprecated.go
+++ b/tools/sgcloudendpoints/deprecated.go
@@ -1,0 +1,100 @@
+package sgcloudendpoints
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+
+	"go.einride.tech/sage/sg"
+	"go.einride.tech/sage/tools/sgdocker"
+	"go.einride.tech/sage/tools/sggcloud"
+)
+
+// ConfigID returns the ID of the latest config for the provided Cloud Endpoints service.
+// Deprecated: Use sgcloudendpoints.DeployConfig instead.
+func ConfigID(ctx context.Context, serviceName, gcpProject string) string {
+	sg.Logger(ctx).Printf(
+		"retrieving endpoints configID from %s in %s...",
+		serviceName,
+		gcpProject,
+	)
+	return sg.Output(sggcloud.Command(
+		ctx,
+		"endpoints",
+		"configs",
+		"list",
+		"--service",
+		serviceName,
+		"--project",
+		gcpProject,
+		"--limit",
+		"1",
+		"--format",
+		"value(id)",
+	))
+}
+
+// DockerImage builds a Cloud Endpoints Docker image.
+// Deprecated: Use sgcloudendpoints.DeployConfig and sgcloudendpoints.BuildImage instead.
+func DockerImage(ctx context.Context, serviceName, gcpProject, gcpRegion string) string {
+	configID := ConfigID(ctx, serviceName, gcpProject)
+	sg.Logger(ctx).Printf(
+		"building image for %s with configID %s...",
+		serviceName,
+		configID,
+	)
+	req, err := http.NewRequestWithContext(
+		ctx,
+		"GET",
+		fmt.Sprintf(
+			"https://servicemanagement.googleapis.com/v1/services/%s/configs/%s?view=FULL",
+			serviceName,
+			configID,
+		),
+		nil,
+	)
+	if err != nil {
+		panic(err)
+	}
+	token := sg.Output(sggcloud.Command(ctx, "auth", "print-access-token"))
+	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	dir, err := os.MkdirTemp(os.TempDir(), "sgcloudendpoints")
+	if err != nil {
+		panic(err)
+	}
+	f, err := os.Create(filepath.Join(dir, "service.json"))
+	if err != nil {
+		panic(err)
+	}
+	if _, err := f.ReadFrom(resp.Body); err != nil {
+		panic(err)
+	}
+	defer func() {
+		_ = f.Close()
+	}()
+	tag := fmt.Sprintf(
+		"%s-docker.pkg.dev/%s/docker/endpoints-runtime-serverless:%s-%s",
+		gcpRegion,
+		gcpProject,
+		serviceName,
+		configID,
+	)
+	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), dockerfile, 0o600); err != nil {
+		panic(err)
+	}
+	cmd := sgdocker.Command(ctx, "build", "-t", tag, ".")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		panic(err)
+	}
+	return tag
+}

--- a/tools/sgcloudendpoints/tools.go
+++ b/tools/sgcloudendpoints/tools.go
@@ -4,100 +4,159 @@ import (
 	"context"
 	_ "embed"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"go.einride.tech/sage/sg"
+	"go.einride.tech/sage/tools/sgbuf"
 	"go.einride.tech/sage/tools/sgdocker"
 	"go.einride.tech/sage/tools/sggcloud"
+	"go.einride.tech/sage/tools/sggooglecloudprotoscrubber"
 )
+
+// espVersion is the version of ESPv2 used for building images.
+const espVersion = "2.37.0"
 
 //go:embed Dockerfile
 var dockerfile []byte
 
-func ConfigID(ctx context.Context, serviceName, gcpProject string) string {
-	sg.Logger(ctx).Printf(
-		"retrieving endpoints configID from %s in %s...",
-		serviceName,
-		gcpProject,
-	)
-
-	return sg.Output(sg.Command(
-		ctx,
-		"gcloud",
-		"endpoints",
-		"configs",
-		"list",
-		"--service",
-		serviceName,
-		"--project",
-		gcpProject,
-		"--limit",
-		"1",
-		"--format",
-		"value(id)",
-	))
+// BuildProtoDescriptor builds a Cloud Endpoints-compatible proto descriptor from the provided Buf module input dir.
+func BuildProtoDescriptor(ctx context.Context, inputDir, outputFile string) error {
+	sg.Logger(ctx).Printf("building descriptor...")
+	if err := os.MkdirAll(filepath.Dir(outputFile), 0o700); err != nil {
+		return err
+	}
+	cmd := sgbuf.Command(ctx, "build", "--exclude-source-info", "-o", outputFile)
+	cmd.Dir = inputDir
+	if err := cmd.Run(); err != nil {
+		return err
+	}
+	return sggooglecloudprotoscrubber.Command(ctx, "-f", outputFile).Run()
 }
 
-func DockerImage(ctx context.Context, serviceName, gcpProject, gcpRegion string) string {
-	dir, err := os.MkdirTemp(os.TempDir(), "sgcloudendpoints")
-	if err != nil {
-		panic(err)
+// DeployConfig deploys the provided config files to Cloud Endpoints and returns the resulting config revision.
+func DeployConfig(ctx context.Context, project string, configFiles ...string) (string, error) {
+	sg.Logger(ctx).Printf("deploying config...")
+	cmd := sggcloud.Command(
+		ctx,
+		append(
+			[]string{
+				"endpoints",
+				"services",
+				"deploy",
+				"--format",
+				"value(serviceConfig.id)",
+				"--project",
+				project,
+			},
+			configFiles...,
+		)...,
+	)
+	var output strings.Builder
+	cmd.Stdout = &output
+	if err := cmd.Run(); err != nil {
+		return "", err
 	}
-	configID := ConfigID(ctx, serviceName, gcpProject)
-	sg.Logger(ctx).Printf(
-		"building image for %s with configID %s...",
-		serviceName,
+	return strings.TrimSpace(output.String()), nil
+}
+
+// ValidateConfig validates the provided config files with Cloud Endpoints.
+func ValidateConfig(ctx context.Context, project string, configFiles ...string) error {
+	sg.Logger(ctx).Printf("validating config...")
+	cmd := sggcloud.Command(
+		ctx,
+		append(
+			[]string{
+				"endpoints",
+				"services",
+				"deploy",
+				"--project",
+				project,
+				"--validate-only",
+			},
+			configFiles...,
+		)...,
+	)
+	cmd.Stdout, cmd.Stderr = nil, nil // suppress noise
+	return cmd.Run()
+}
+
+// BuildImage builds a container image with a baked-in Cloud Endpoints service configuration.
+func BuildImage(ctx context.Context, project, region, repo, service, configID string) (string, error) {
+	sg.Logger(ctx).Printf("building image...")
+	config, err := GetServiceConfig(ctx, service, configID)
+	if err != nil {
+		return "", err
+	}
+	buildRoot := sg.FromBuildDir("cloud-endpoints")
+	if err := os.MkdirAll(buildRoot, 0o700); err != nil {
+		return "", err
+	}
+	buildDir, err := os.MkdirTemp(buildRoot, "docker")
+	if err != nil {
+		return "", err
+	}
+	defer func() {
+		_ = os.RemoveAll(buildDir)
+	}()
+	if err := os.WriteFile(filepath.Join(buildDir, "Dockerfile"), dockerfile, 0o600); err != nil {
+		return "", err
+	}
+	if err := os.WriteFile(filepath.Join(buildDir, "service.json"), []byte(config), 0o600); err != nil {
+		return "", err
+	}
+	image := fmt.Sprintf(
+		"%s-docker.pkg.dev/%s/%s/endpoints-runtime-serverless:%s-%s-%s",
+		region,
+		project,
+		repo,
+		espVersion,
+		service,
 		configID,
 	)
-	req, err := http.NewRequestWithContext(
+	if err := sgdocker.Command(
+		ctx, "build", "-t", image, "--build-arg", "esp_version="+espVersion, buildDir,
+	).Run(); err != nil {
+		return "", err
+	}
+	return image, nil
+}
+
+// GetServiceConfig fetches a full service config from Cloud Endpoints.
+func GetServiceConfig(ctx context.Context, service, configID string) (string, error) {
+	var accessTokenOutput strings.Builder
+	cmd := sggcloud.Command(ctx, "auth", "print-access-token")
+	cmd.Stdout = &accessTokenOutput
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	request, err := http.NewRequestWithContext(
 		ctx,
-		"GET",
+		http.MethodGet,
 		fmt.Sprintf(
 			"https://servicemanagement.googleapis.com/v1/services/%s/configs/%s?view=FULL",
-			serviceName,
+			service,
 			configID,
 		),
 		nil,
 	)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	token := sg.Output(sggcloud.Command(ctx, "auth", "print-access-token"))
-	req.Header.Set("Authorization", fmt.Sprintf("Bearer %s", token))
-
-	resp, err := http.DefaultClient.Do(req)
+	request.Header.Set("Authorization", "Bearer "+strings.TrimSpace(accessTokenOutput.String()))
+	response, err := http.DefaultClient.Do(request)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
 	defer func() {
-		_ = resp.Body.Close()
+		_ = response.Body.Close()
 	}()
-	f, err := os.Create(filepath.Join(dir, "service.json"))
+	result, err := io.ReadAll(response.Body)
 	if err != nil {
-		panic(err)
+		return "", err
 	}
-	if _, err := f.ReadFrom(resp.Body); err != nil {
-		panic(err)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-	tag := fmt.Sprintf(
-		"%s-docker.pkg.dev/%s/docker/endpoints-runtime-serverless:%s-%s",
-		gcpRegion,
-		gcpProject,
-		serviceName,
-		configID,
-	)
-	if err := os.WriteFile(filepath.Join(dir, "Dockerfile"), dockerfile, 0o600); err != nil {
-		panic(err)
-	}
-	cmd := sgdocker.Command(ctx, "build", "-t", tag, ".")
-	cmd.Dir = dir
-	if err := cmd.Run(); err != nil {
-		panic(err)
-	}
-	return tag
+	return strings.TrimSpace(string(result)), nil
 }


### PR DESCRIPTION
Split the DockerImage helper into the more composable DeployConfig and
BuildImage helpers.

No longer assume that the Artifact Registry is called `docker`.
