### PR TITLE
feat(sgfirebasetools): add option for channel expiration

### DIFF
--- a/tools/sgfirebasetools/tool.go
+++ b/tools/sgfirebasetools/tool.go
@@ -26,6 +26,10 @@ type DeployPreviewOptions struct {
 	ChannelID string
 	// CmdDir can be set if the firebase.json file is not in root of repository.
 	CmdDir string
+	// Expires sets the duration until channel expires.
+	// Defaults to 7 days.
+	// Examples: "12h", "7d", "30d"
+	Expires string
 }
 
 // DeployPreview deploy static files to a Firebase hosting channel. Returns the generated URL
@@ -39,6 +43,9 @@ func DeployPreview(ctx context.Context, opts DeployPreviewOptions) (string, erro
 	}
 	if opts.Site != "" {
 		args = append(args, "--only", opts.Site)
+	}
+	if opts.Expires != "" {
+		args = append(args, "--expires", opts.Expires)
 	}
 	cmd := Command(
 		ctx,


### PR DESCRIPTION
By default firebase sets the expiry of a channel to 7 days.
In projects with a lot of activity this can lead to the quota of
channels (50) to be hit, preventing all furhter deployments.

By setting a quicker expiration this can be avoided.
