### PR TITLE
chore(sggolangcilint): bump golangci-lint to 1.48.0 (go1.19 support)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea/
+.vscode/

--- a/internal/codegen/file.go
+++ b/internal/codegen/file.go
@@ -78,7 +78,7 @@ func (f *File) Write(p []byte) (int, error) {
 	if err != nil {
 		f.err = fmt.Errorf("write: %w", err)
 	}
-	return n, err // nolint: wrapcheck // false positive
+	return n, err //nolint: wrapcheck // false positive
 }
 
 // RawContent returns the raw content of the file.

--- a/sg/exec.go
+++ b/sg/exec.go
@@ -14,7 +14,7 @@ import (
 
 type cmdEnvCtxKey string
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var cmdEnvKey cmdEnvCtxKey = "cmdEnv"
 
 // ContextWithEnv returns a context with environment variables which are appended to Command.

--- a/sg/internal/runner/runner.go
+++ b/sg/internal/runner/runner.go
@@ -6,7 +6,7 @@ import (
 )
 
 // global state for the runner.
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var (
 	mu      sync.Mutex
 	onceFns = map[string]func(context.Context) error{}

--- a/sgtool/file.go
+++ b/sgtool/file.go
@@ -247,7 +247,7 @@ func (s *fileState) downloadBinary(ctx context.Context, url string) (io.ReadClos
 	}
 
 	req.Header = s.httpHeader
-	// nolint: bodyclose // false positive due to cleanup function
+	//nolint: bodyclose // false positive due to cleanup function
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, func() {}, fmt.Errorf("download binary %s: %w", url, err)
@@ -270,7 +270,7 @@ func (s *fileState) extractZip(reader *zip.Reader) ([]string, error) {
 		}
 
 		// Store filename/path for returning and using later on
-		// nolint: gosec // allow file traversal when extracting archive
+		//nolint: gosec // allow file traversal when extracting archive
 		fpath := filepath.Join(s.dstPath, dstName)
 
 		// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
@@ -298,7 +298,7 @@ func (s *fileState) extractZip(reader *zip.Reader) ([]string, error) {
 			return filenames, err
 		}
 
-		// nolint: gosec // allow potential decompression bomb
+		//nolint: gosec // allow potential decompression bomb
 		_, err = io.Copy(outFile, rc)
 
 		// Close the file without defer to close before next iteration of loop
@@ -332,7 +332,7 @@ func (s *fileState) extractTar(reader io.Reader) error {
 			dstName = name
 		}
 
-		// nolint: gosec // allow traversal into archive
+		//nolint: gosec // allow traversal into archive
 		path := filepath.Join(s.dstPath, dstName)
 
 		switch header.Typeflag {
@@ -360,7 +360,7 @@ func (s *fileState) extractTar(reader io.Reader) error {
 			if err := os.Chmod(path, 0o775); err != nil {
 				return fmt.Errorf("extractTar: Chmod() failed: %w", err)
 			}
-			// nolint: gosec // allow potential decompression bomb
+			//nolint: gosec // allow potential decompression bomb
 			if _, err := io.Copy(outFile, tarReader); err != nil {
 				return fmt.Errorf("extractTar: Copy() failed: %w", err)
 			}

--- a/tools/sgcommitlint/tools.go
+++ b/tools/sgcommitlint/tools.go
@@ -27,7 +27,7 @@ const commitlintFileContent = `module.exports = {
 
 const name = "commitlint"
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var commitlintrc = sg.FromToolsDir("commitlint", ".commitlintrc.js")
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -1,6 +1,6 @@
 run:
   timeout: 10m
-  allow-parallel-runners: true
+  allow-parallel-runners: false
 
 issues:
   fix: true

--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -84,10 +84,6 @@ linters:
     # [fast: false, auto-fix: false]
     - govet
 
-    # Check that code uses short syntax for if-statements whenever possible.
-    # [fast: true, auto-fix: false]
-    - ifshort
-
     # Detect when assignments to existing variables are not used.
     # [fast: true, auto-fix: false]
     - ineffassign

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.47.1"
+	version = "1.48.0"
 )
 
 //go:embed golangci.yml

--- a/tools/sggolangmigrate/tools.go
+++ b/tools/sggolangmigrate/tools.go
@@ -16,7 +16,7 @@ const (
 	name    = "migrate"
 )
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggooglecloudprotoscrubber/tools.go
+++ b/tools/sggooglecloudprotoscrubber/tools.go
@@ -14,7 +14,7 @@ import (
 
 const version = "1.1.0"
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggrpcjava/tools.go
+++ b/tools/sggrpcjava/tools.go
@@ -13,7 +13,7 @@ import (
 
 const version = "1.45.1"
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var commandPath string
 
 func Command(ctx context.Context) *exec.Cmd {

--- a/tools/sghadolint/tools.go
+++ b/tools/sghadolint/tools.go
@@ -18,7 +18,7 @@ import (
 // version can be found here: https://github.com/hadolint/hadolint
 const version = "2.8.0"
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgmarkdownfmt/tools.go
+++ b/tools/sgmarkdownfmt/tools.go
@@ -10,7 +10,7 @@ import (
 
 const version = "75134924a9fd3335f76a9709314c5f5cef4d6ddc"
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgnpmlicense/tools.go
+++ b/tools/sgnpmlicense/tools.go
@@ -12,7 +12,7 @@ import (
 
 // @TODO consider replacing this with https://www.npmjs.com/package/license-checker-rseidelsohn
 const (
-	// nolint: lll
+	//nolint: lll
 	banList            = "UNLICENCED;GPL-1.0-or-later;LGPL-2.0-or-later;AGPL-3.0;MS-PL;SPL-1.0;CC-BY-NC-1.0;CC-BY-NC-2.0;CC-BY-NC-2.5;CC-BY-NC-4.0;CC-BY-NC-ND-1.0;CC-BY-NC-ND-2.0;CC-BY-NC-ND-2.5;CC-BY-NC-ND-4.0;CC-BY-NC-SA-1.0;CC-BY-NC-SA-2.0;CC-BY-NC-SA-2.5;CC-BY-NC-SA-4.0;EUPL-1.0;EUPL-1.1;EUPL-1.2"
 	name               = "license-checker"
 	packageJSONContent = `{

--- a/tools/sgprettier/tools.go
+++ b/tools/sgprettier/tools.go
@@ -23,7 +23,7 @@ const prettierConfigContent = `module.exports = {
 
 const name = "prettier"
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var prettierrc = sg.FromToolsDir("prettier", ".prettierrc.js")
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgprotoc/tools.go
+++ b/tools/sgprotoc/tools.go
@@ -14,7 +14,7 @@ import (
 
 const version = "3.15.7"
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgprotocgentypescriptaip/tools.go
+++ b/tools/sgprotocgentypescriptaip/tools.go
@@ -30,7 +30,7 @@ func PrepareCommand(ctx context.Context) error {
 	if hostArch == sgtool.AMD64 {
 		hostArch = sgtool.X8664
 	}
-	// nolint: lll
+	//nolint: lll
 	downloadURL := fmt.Sprintf(
 		"https://github.com/einride/protoc-gen-typescript-aip/releases/download/v%s/protoc-gen-typescript-aip_%s_%s_%s.tar.gz",
 		version,

--- a/tools/sgprotocgentypescripthttp/tools.go
+++ b/tools/sgprotocgentypescripthttp/tools.go
@@ -30,7 +30,7 @@ func PrepareCommand(ctx context.Context) error {
 	if hostArch == sgtool.AMD64 {
 		hostArch = sgtool.X8664
 	}
-	// nolint: lll
+	//nolint: lll
 	downloadURL := fmt.Sprintf(
 		"https://github.com/einride/protoc-gen-typescript-http/releases/download/v%s/protoc-gen-typescript-http_%s_%s_%s.tar.gz",
 		version,

--- a/tools/sgsops/tools.go
+++ b/tools/sgsops/tools.go
@@ -13,7 +13,7 @@ import (
 
 const version = "3.7.1"
 
-// nolint: gochecknoglobals
+//nolint: gochecknoglobals
 var commandPath string
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
- chore(sggolangcilint): bump golangci-lint to 1.48.0 (go1.19 support)
- chore(sggolangcilint): remove deprecated linter `ifshort`
