### PR TITLE
feat(sgdbt): bump dbt to 1.2.0

### DIFF
--- a/tools/sgdbt/tools.go
+++ b/tools/sgdbt/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name                   = "dbt"
-	bigqueryPackageVersion = "1.0.0"
+	bigqueryPackageVersion = "1.2.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
If approved, this PR will:

- Update the dbt version of the sage dbt tool to `1.2.0`

Current version, `1.0.0`, does not support Python 3.10 - which newer versions of linux distributions such as ubuntu has installed by default.