### PR TITLE
feat: disable go.work support if not explicitly set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,6 +8,7 @@ sagefile := $(abspath $(cwd)/.sage/bin/sagefile)
 
 # Setup Go.
 go := $(shell command -v go 2>/dev/null)
+export GOWORK ?= off
 ifndef go
 SAGE_GO_VERSION ?= 1.18.4
 export GOROOT := $(abspath $(cwd)/.sage/tools/go/$(SAGE_GO_VERSION)/go)

--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -62,6 +62,7 @@ func generateMakefile(ctx context.Context, g *codegen.File, pkg *doc.Package, mk
 	g.P()
 	g.P("# Setup Go.")
 	g.P("go := $(shell command -v go 2>/dev/null)")
+	g.P("export GOWORK ?= off")
 	g.P("ifndef go")
 	g.P("SAGE_GO_VERSION ?= ", defaultGoVersion)
 	g.P("export GOROOT := $(abspath $(cwd)/", filepath.Join(includePath, toolsDir, "go", "$(SAGE_GO_VERSION)", "go"), ")")


### PR DESCRIPTION
If the local environment does not explicitly set GOWORK=on then we disable go.work support to avoid issues with multi-module repos that are not meant to keep the different modules in sync
