### PR TITLE
feat(setupsage): bump default go ver to v1.19

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -10,7 +10,7 @@ inputs:
   go-version:
     description: The Go version to download (if necessary) and use. Supports semver spec and ranges.
     required: false
-    default: 1.18
+    default: 1.19
 
   fetch-depth:
     description: Number of commits to fetch. 0 indicates all history for all branches and tags.


### PR DESCRIPTION
I received `[go-mod-tidy] go: go.mod file indicates go 1.19, but maximum version supported by tidy is 1.18` in my github action CI after an attempted bump to golang v1.19. Time to bump the default, Y/N?