### PR TITLE
feat: add clean alias

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -43,6 +43,9 @@ update-sage: $(go)
 clean-sage:
 	@git clean -fdx .sage/tools .sage/bin .sage/build
 
+.PHONY: clean
+clean: clean-sage
+
 .PHONY: convco-check
 convco-check: $(sagefile)
 	@$(sagefile) ConvcoCheck

--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -103,6 +103,9 @@ func generateMakefile(ctx context.Context, g *codegen.File, pkg *doc.Package, mk
 		" ",
 		filepath.Join(includePath, buildDir),
 	)
+	g.P()
+	g.P(".PHONY: clean")
+	g.P("clean: clean-sage")
 	forEachTargetFunction(pkg, func(function *doc.Func, namespace *doc.Type) {
 		if function.Recv == mk.namespaceName() {
 			g.P()


### PR DESCRIPTION
This should allow `make clean` to work the same way as `make clean-sage`? My assumption is that as sage is heavily glued into our build system, whenever we need to do a clean operation it will be ended up as doing `make clean-sage`. Instead of renaming `clean-sage` to `clean`, adding this alias is perhaps more backward compatible?

I am totally fine we just close this PR if we think this just brings noise but no actual benefits. As I am learning about Makefiles and sage at the moment, I guess this change does what I intend to do, and perhaps this is something nice to have?

---

I tried to test this change locally by running `go build` and using the generated `sage` file in an empty project and running it as `sage init` to generate a Makefile, but not sure why my change in the local go file is not taking any effect. Still puzzled about it...