### PR TITLE
feat: update cache if go version changed

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -37,9 +37,9 @@ runs:
         path: |
           ~/.cache/go-build
           ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ inputs.cacheKey }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ runner.os }}-go-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-go-${{ inputs.cacheKey }}-
+          ${{ runner.os }}-go-${{ inputs.cacheKey }}-${{ inputs.go-version }}-
 
     - name: Cache sage folders
       uses: actions/cache@v3
@@ -47,6 +47,6 @@ runs:
         path: |
           ./.sage/tools
           ./.sage/bin
-        key: ${{ runner.os }}-sage-${{ inputs.cacheKey }}-${{ hashFiles('./.sage/go.sum') }}
+        key: ${{ runner.os }}-sage-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('./.sage/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-sage-${{ inputs.cacheKey }}-
+          ${{ runner.os }}-sage-${{ inputs.cacheKey }}-${{ inputs.go-version }}-


### PR DESCRIPTION
to avoid cache is used when go version gets updated.

An example issue we have is build like this failed on master
https://github.com/einride/vehicle-service/actions/runs/3052245767/jobs/4921413170

but works on PR build (which sage get pulled)

The issue, seeing from the log, that on master build the cache is used, but as we recently updated go version, the generated files changed format so on master build we will have to update cache as well (or we need to manually call `make clea-sage` each time for the master build, I suppose...?)

If this `${{ inputs.go-version }}` can get evaluated correctly, I think it can unblock our master build filling issue.