### PR TITLE
fix(sggolangcilint): turn off --path-prefix option for now

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -49,15 +49,19 @@ func Run(ctx context.Context, args ...string) error {
 		if _, err := os.Lstat(configPath); errors.Is(err, os.ErrNotExist) {
 			configPath = defaultConfigPath
 		}
-		pathPrefix, err := filepath.Rel(sg.FromGitRoot(), filepath.Dir(path))
-		if err != nil {
-			return err
-		}
+		// Temporarily commenting usage of --path-prefix out below to solve an issue
+		// like this https://github.com/golangci/golangci-lint/issues/3195
+		//
+		// pathPrefix, err := filepath.Rel(sg.FromGitRoot(), filepath.Dir(path))
+		// if err != nil {
+		// 	return err
+		// }
+		// cmdArgs := append([]string{"run", "-c", configPath, "--path-prefix", pathPrefix}, args...)
+		cmdArgs := append([]string{"run", "-c", configPath}, args...)
 		var excludeArg []string
 		if filepath.Dir(path) == sg.FromSageDir() {
 			excludeArg = append(excludeArg, "--exclude", "(is a global variable|is unused)")
 		}
-		cmdArgs := append([]string{"run", "-c", configPath, "--path-prefix", pathPrefix}, args...)
 		cmd := Command(ctx, append(cmdArgs, excludeArg...)...)
 		cmd.Dir = filepath.Dir(path)
 		commands = append(commands, cmd)


### PR DESCRIPTION
I am having some similar issues as mentioned here:
https://github.com/golangci/golangci-lint/issues/3195

```
[go-lint] 
.sage/sagefile.go:5: File is not `gci`-ed with --skip-generated -s standard,default (gci)
"go.einride.tech/sage/sgtool"
.sage/sagefile.go:7: File is not `gci`-ed with --skip-generated -s standard,default (gci)
"go.einride.tech/sage/sg"
[go-lint] level=error msg="Failed to fix issues in file .sage/sagefile.go: failed to get file bytes for .sage/sagefile.go: can't read file .sage/sagefile.go: open .sage/sagefile.go: no such file or directory"
[go-lint] exit status 1
make: *** [default] Error 1
```

not sure how wide the impact is as this issue sometimes comes to me and sometimes does not.

If it only happening on me, then I can perhaps survive by using a local sage repo.