### PR TITLE
feat: bump tool versions (sep 2022)

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.34.0"
+	version = "1.36.0"
 	name    = "api-linter"
 )
 

--- a/tools/sgbuf/tools.go
+++ b/tools/sgbuf/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "1.7.0"
+	version = "1.8.0"
 	name    = "buf"
 )
 

--- a/tools/sggh/tools.go
+++ b/tools/sggh/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "gh"
-	version = "2.7.0"
+	version = "2.15.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggolangmigrate/tools.go
+++ b/tools/sggolangmigrate/tools.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "4.15.1"
+	version = "4.15.2"
 	name    = "migrate"
 )
 

--- a/tools/sgprotoc/tools.go
+++ b/tools/sgprotoc/tools.go
@@ -12,7 +12,7 @@ import (
 	"go.einride.tech/sage/sgtool"
 )
 
-const version = "3.15.7"
+const version = "3.19.5"
 
 //nolint: gochecknoglobals
 var commandPath string

--- a/tools/sgprotocgengoaiptest/tools.go
+++ b/tools/sgprotocgengoaiptest/tools.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	version = "0.8.0"
+	version = "0.8.1"
 	name    = "protoc-gen-go-aip-test"
 )
 

--- a/tools/sgprotocgengogrpcserviceconfig/tools.go
+++ b/tools/sgprotocgengogrpcserviceconfig/tools.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	version = "0.5.0"
+	version = "0.6.0"
 	name    = "protoc-gen-go-grpc-service-config"
 )
 

--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version    = "1.2.7"
+	version    = "1.2.9"
 	binaryName = "terraform"
 )
 

--- a/tools/sgtfsec/tools.go
+++ b/tools/sgtfsec/tools.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "1.19.1"
+	version = "1.27.6"
 	name    = "tfsec"
 )
 

--- a/tools/sgyq/tools.go
+++ b/tools/sgyq/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "yq"
-	version = "4.26.1"
+	version = "4.27.5"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
- feat(api-linter): bump to 1.36.0
- feat(buf): bump to 1.8.0
- feat(gh): bump to 2.15.0
- feat(golang-migrate): bump to 4.15.2
- feat(protoc): bump to 3.19.5
- feat(protoc-gen-go-aip-test): bump to 0.8.1
- feat(protoc-gen-go-grpc-service-config): bump to 0.6.0
- feat(terraform): bump to 1.2.9
- feat(tfsec): bump to 1.27.6
- feat(yq): bump to 4.27.5
