### PR TITLE
feat(api-linter): downgrade to 1.35.1

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.36.0"
+	version = "1.35.1"
 	name    = "api-linter"
 )
 


### PR DESCRIPTION
Version 1.36.0 does not have any binaries uploaded to it on GitHub
releases.
