### PR TITLE
feat(yamlfmt): add `google/yamlfmt` over `einride/yamlfmt`

### DIFF
--- a/.sage/sagefile.go
+++ b/.sage/sagefile.go
@@ -10,6 +10,7 @@ import (
 	"go.einride.tech/sage/tools/sggolangcilint"
 	"go.einride.tech/sage/tools/sggoreview"
 	"go.einride.tech/sage/tools/sgmarkdownfmt"
+	"go.einride.tech/sage/tools/sgyamlfmt"
 )
 
 func main() {
@@ -22,7 +23,7 @@ func main() {
 }
 
 func Default(ctx context.Context) error {
-	sg.Deps(ctx, ConvcoCheck, GoLint, GoReview, GoTest, FormatMarkdown)
+	sg.Deps(ctx, ConvcoCheck, GoLint, GoReview, GoTest, FormatMarkdown, FormatYaml)
 	sg.SerialDeps(ctx, GoModTidy, GitVerifyNoDiff)
 	return nil
 }
@@ -50,6 +51,11 @@ func GoLint(ctx context.Context) error {
 func FormatMarkdown(ctx context.Context) error {
 	sg.Logger(ctx).Println("formatting Markdown files...")
 	return sgmarkdownfmt.Command(ctx, "-w", ".").Run()
+}
+
+func FormatYaml(ctx context.Context) error {
+	sg.Logger(ctx).Println("formatting Yaml files...")
+	return sgyamlfmt.Run(ctx)
 }
 
 func ConvcoCheck(ctx context.Context) error {

--- a/Makefile
+++ b/Makefile
@@ -54,6 +54,10 @@ default: $(sagefile)
 format-markdown: $(sagefile)
 	@$(sagefile) FormatMarkdown
 
+.PHONY: format-yaml
+format-yaml: $(sagefile)
+	@$(sagefile) FormatYaml
+
 .PHONY: git-verify-no-diff
 git-verify-no-diff: $(sagefile)
 	@$(sagefile) GitVerifyNoDiff

--- a/example/.sage/sagefile.go
+++ b/example/.sage/sagefile.go
@@ -10,6 +10,7 @@ import (
 	"go.einride.tech/sage/tools/sggolangcilint"
 	"go.einride.tech/sage/tools/sggoreview"
 	"go.einride.tech/sage/tools/sgmarkdownfmt"
+	"go.einride.tech/sage/tools/sgyamlfmt"
 )
 
 func main() {
@@ -22,7 +23,7 @@ func main() {
 }
 
 func Default(ctx context.Context) error {
-	sg.Deps(ctx, ConvcoCheck, FormatMarkdown)
+	sg.Deps(ctx, ConvcoCheck, FormatMarkdown, FormatYaml)
 	sg.Deps(ctx, GoLint, GoReview)
 	sg.Deps(ctx, GoTest)
 	sg.SerialDeps(ctx, GoModTidy, GitVerifyNoDiff)
@@ -52,6 +53,11 @@ func GoLint(ctx context.Context) error {
 func FormatMarkdown(ctx context.Context) error {
 	sg.Logger(ctx).Println("formatting Markdown files...")
 	return sgmarkdownfmt.Command(ctx, "-w", ".").Run()
+}
+
+func FormatYaml(ctx context.Context) error {
+	sg.Logger(ctx).Println("formatting Yaml files...")
+	return sgyamlfmt.Run(ctx)
 }
 
 func ConvcoCheck(ctx context.Context) error {

--- a/tools/sgyamlfmt/yamlfmt.yaml
+++ b/tools/sgyamlfmt/yamlfmt.yaml
@@ -1,0 +1,3 @@
+formatter:
+  type: basic
+  retain_line_breaks: true


### PR DESCRIPTION
this deprecates `github.com/einride/yamlfmt` in favor of
`github.com/google/yamlfmt`

A reason for this is its support of retaining line breaks when
formatting
