### PR TITLE
chore(convco): update to version 0.3.12

### DIFF
--- a/tools/sgconvco/tools.go
+++ b/tools/sgconvco/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "convco"
-	version = "0.3.8"
+	version = "0.3.12"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
Update to new version https://github.com/convco/convco/releases/tag/v0.3.12

`--ignore-reverts` is introduced with the new version and if people want they can turn it on for their backend service so those Github `Revert` button generated message will be ignored by convco check.

Noticing a side effect is the changelogs will also miss this `Revert "some last commit message"` as well. But I guess for backend services the changelogs are not that important so perhaps it is fine.