### PR TITLE
fix(golangcilint): disable auto fixing

### DIFF
--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -5,7 +5,7 @@ run:
     - node_modules
 
 issues:
-  fix: true
+  fix: false
 
 linters:
   disable-all: true


### PR DESCRIPTION
There seem to be race conditions between linters and fixers when running in parallel.

Prefer finding as many lint errors as possible, as opposed to convenience of auto fixing.