### PR TITLE
feat: bubble up `check-latest` option from setup-go

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -12,6 +12,11 @@ inputs:
     required: false
     default: 1.18
 
+  check-latest:
+    description: If true, checks whether the cached go version is the latest, if not then downloads the latest. Useful when you need to use the latest version.
+    required: false
+    default: false
+
   fetch-depth:
     description: Number of commits to fetch. 0 indicates all history for all branches and tags.
     default: 0
@@ -30,6 +35,7 @@ runs:
       uses: actions/setup-go@v3
       with:
         go-version: ${{ inputs.go-version }}
+        check-latest: ${{ inputs.check-latest }}
 
     - name: Cache Go modules
       uses: actions/cache@v3


### PR DESCRIPTION
Within the github workflows we want to not need to specify the patch
version of Go and always get the latest. Unfortunately cache
invalidation is a hard problem so this will bubble up the check-latest
flag from the setup-go action so that this can be specified optionally
for services.
