### PR TITLE
feat(terraform): bump to v1.3.2

### DIFF
--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version    = "1.2.9"
+	version    = "1.3.2"
 	binaryName = "terraform"
 )
 


### PR DESCRIPTION
This upgrades terraform to the latest version (v1.3.2).

Looking through the release notes there is nothing that breaks how sage is using terraform.

The main thing that it introduces is two new string functions: `startswith` and `endswith` that will be very useful, especially for variable validation.

The full release notes can be found below:

- [v1.3.2](https://github.com/hashicorp/terraform/releases/tag/v1.3.2)
- [v1.3.1](https://github.com/hashicorp/terraform/releases/tag/v1.3.1)
- [v1.3.0](https://github.com/hashicorp/terraform/releases/tag/v1.3.0)
