### PR TITLE
feat(sqlc): bump to v1.15.0

### DIFF
--- a/tools/sgsqlc/tools.go
+++ b/tools/sgsqlc/tools.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "1.14.0"
+	version = "1.15.0"
 	name    = "sqlc"
 )
 


### PR DESCRIPTION
In sqlc v1.15.0 they have introduced the concept of nullable enum types.

Full release notes can be found [here](https://github.com/kyleconroy/sqlc/releases/tag/v1.15.0)
