### PR TITLE
chore(dbt): bump dbt-bigquery version 1.2.0 -> 1.3.0

### DIFF
--- a/tools/sgdbt/tools.go
+++ b/tools/sgdbt/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name                   = "dbt"
-	bigqueryPackageVersion = "1.2.0"
+	bigqueryPackageVersion = "1.3.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
If approved this PR will:
Bump the version of dbt-bigquery 1.2.0 --> 1.3.0
[Full change log found here](https://github.com/dbt-labs/dbt-bigquery/releases/tag/v1.3.0)