### PR TITLE
feat(sggolangcilint): bump to version 1.50.1

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.50.0"
+	version = "1.50.1"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Got segmentation fault error with version 1.50, but works with 1.50.1.
```
[go-lint] running...                                                                                                                                                                                              
[go-lint] signal: segmentation fault                                                                                                                                                                              
make: *** [sage.mk:80: go-lint] Error 1  
```