### PR TITLE
fix(sgphrase): download binary instead of tar ball

### DIFF
--- a/tools/sgphrase/tools.go
+++ b/tools/sgphrase/tools.go
@@ -33,7 +33,7 @@ func PrepareCommand(ctx context.Context) error {
 	}
 	hostArch := runtime.GOARCH
 	binURL := fmt.Sprintf(
-		"https://github.com/phrase/phrase-cli/releases/download/%s/phrase_%s_%s.tar.gz",
+		"https://github.com/phrase/phrase-cli/releases/download/%s/phrase_%s_%s",
 		version,
 		hostOS,
 		hostArch,
@@ -42,7 +42,7 @@ func PrepareCommand(ctx context.Context) error {
 		ctx,
 		binURL,
 		sgtool.WithDestinationDir(binDir),
-		sgtool.WithUntarGz(),
+		sgtool.WithRenameFile("", binaryName),
 		sgtool.WithSkipIfFileExists(binary),
 		sgtool.WithSymlink(binary),
 	); err != nil {


### PR DESCRIPTION
The binary name inside the tar ball for macosx and linux is different. Download and rename the binary instead.