### PR TITLE
revert(actions): add input to checkout different branch than default

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -21,10 +21,6 @@ inputs:
     description: Number of commits to fetch. 0 indicates all history for all branches and tags.
     default: 0
 
-  git-branch:
-    description: What branch to checkout
-    default: master
-
 runs:
   using: composite
 
@@ -34,7 +30,6 @@ runs:
       with:
         # Needed for conventional commit linting.
         fetch-depth: ${{ inputs.fetch-depth }}
-        ref: ${{ inputs.git-branch }}
 
     - name: Set up Go
       uses: actions/setup-go@v3


### PR DESCRIPTION
This reverts commit e443bb44aea63957b34a37474e1ec44dadaa2fc2.

Specifying a branch, or defaulting to master, makes PR tests run on the latest commit on that branch, not on the PR commit.