### PR TITLE
feat: update api-linter to v1.37.0

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.36.2"
+	version = "1.37.0"
 	name    = "api-linter"
 )
 


### PR DESCRIPTION
Here are the release notes: https://github.com/googleapis/api-linter/releases/tag/v1.37.0
