### PR TITLE
feat(sglogger): add namespace prefix to logger

### DIFF
--- a/sg/logger.go
+++ b/sg/logger.go
@@ -6,7 +6,6 @@ import (
 	"log"
 	"os"
 	"strings"
-	"unicode"
 
 	"go.einride.tech/sage/internal/strcase"
 )
@@ -18,11 +17,11 @@ func NewLogger(name string) *log.Logger {
 	prefix := name
 	prefix = strings.TrimPrefix(prefix, "main.")
 	prefix = strings.TrimPrefix(prefix, "go.einride.tech/sage/tools/")
-	// Strip namespace from name.
+
+	// Separate namespace and target with colon, expecting the string to be
+	// of the format `namespace.target`.
 	if len(strings.Split(prefix, ".")) > 1 {
-		if unicode.IsUpper([]rune(strings.Split(prefix, ".")[0])[0]) {
-			prefix = strings.Join(strings.Split(prefix, ".")[1:], "")
-		}
+		prefix = strings.Join(strings.Split(prefix, "."), ":")
 	}
 	prefix = strcase.ToKebab(prefix)
 	prefix = fmt.Sprintf("[%s] ", prefix)


### PR DESCRIPTION
This PR is maybe a bit controversial, so I am happy to close it if it is disliked 😅 

This partly reverts 760385e3556f65800ed1bfb9b3642be12b39d923, but adds the namespace in the prefix separated by a colon.

Examples:
- behavior with this commit:
  `[service:go-lint] linting Go files...`
- behavior before this commit:
  `[go-lint] linting Go files...`
- behavior before 760385e3556f65800ed1bfb9b3642be12b39d923
  `[service-go-lint] linting Go files...`

This could be useful when running a lot of targets in different namespaces in parallel, e.g. a CI pipeline running `go-lint` in multiple services concurrently, to know which namespace the log line relates to.