### PR TITLE
fix(gha-actions): evaluate composite input bool as string

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -43,7 +43,7 @@ runs:
         check-latest: ${{ inputs.check-latest }}
 
     - name: Cache Go modules
-      if: ${{ !inputs.disableCache }}
+      if: ${{ inputs.disableCache != 'true' }}
       uses: actions/cache@v3
       with:
         path: |
@@ -54,7 +54,7 @@ runs:
           ${{ runner.os }}-go-${{ inputs.cacheKey }}-${{ inputs.go-version }}-
 
     - name: Cache sage folders
-      if: ${{ !inputs.disableCache }}
+      if: ${{ inputs.disableCache != 'true' }}
       uses: actions/cache@v3
       with:
         path: |


### PR DESCRIPTION
https://github.com/actions/runner/issues/1483
https://github.com/actions/runner/issues/1483#issuecomment-1279933184

---

I've noticed that several CI jobs have been pretty slow recently and most repositories have empty caches (e.g., pick any repository, go to **Actions** -> **Caches**)

Example log when running the composite setup sage action,

Currently (no `actions/cache@v3` log row):

<img width="310" alt="Screenshot 2022-12-02 at 15 09 37" src="https://user-images.githubusercontent.com/7148604/205312609-db09dcad-ae1c-4ca9-8234-c213d097a34e.png">

After this change:

<img width="239" alt="Screenshot 2022-12-02 at 15 13 56" src="https://user-images.githubusercontent.com/7148604/205312562-1f6670e1-c915-4700-8ac3-df7dbd2d1a13.png">
