### PR TITLE
fix(sgnpmlicense): output summary instead of csv

### DIFF
--- a/tools/sgnpmlicense/tools.go
+++ b/tools/sgnpmlicense/tools.go
@@ -246,7 +246,7 @@ func LicenseCheckerCommand(ctx context.Context) *exec.Cmd {
 
 	args := []string{
 		"--excludePrivatePackages",
-		"--csv",
+		"--summary",
 		"--failOn",
 		strings.Join([]string{forbiddenType, restrictedType}, ";"),
 	}


### PR DESCRIPTION
The csv format outputs one row per dependency. The list of all
dependencies (incl. transitive) in most projects is huge, which means
this command spits out hundreds of lines even when everything is fine.

The summary format is at least limited to the number of used licenses in
project dependencies (~10-20).
