### PR TITLE
chore(sgmvn): bump mvn from 3.8.6 to 3.8.7

### DIFF
--- a/tools/sgmvn/tools.go
+++ b/tools/sgmvn/tools.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	name    = "mvn"
-	version = "3.8.6"
+	version = "3.8.7"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
3.8.6 is inaccessible and therefore the optimizer core builds fail, like this one: https://console.cloud.google.com/cloud-build/builds/95c4a640-10c9-4d4f-9d60-40f9f3f6ac7a?project=einride-vrp-optimizer-core