### PR TITLE
feat: mark Makefile's as generated for GitHub

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+Makefile linguist-generated=true

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ go run go.einride.tech/sage@latest init
 
 Run `make`.
 
-Two changes should now have happened. If the project had a previous `Makefile` it should have been renamed to `Makefile.old` and a new should have been created. If the project have a dependabot config, a sage config should have been added.
+Three changes should now have happened. If the project had a previous `Makefile` it should have been renamed to `Makefile.old` and a new should have been created. If the project have a dependabot config, a sage config should have been added. GitHub should treat Makefiles as generated code by listing it in `.gitattributes`.
 
 Usage
 -----

--- a/example/.gitattributes
+++ b/example/.gitattributes
@@ -1,0 +1,1 @@
+Makefile linguist-generated=true


### PR DESCRIPTION
Using the `linguist-generated` directive in .gitattributes, this tells GitHub that the Makefile's should be treated as generated files and by default not display its diff in PRs.

See documentation:
https://docs.github.com/en/repositories/working-with-files/managing-files/customizing-how-changed-files-appear-on-github