### PR TITLE
feat(firebase): limit preview deploymnet to project

### DIFF
--- a/tools/sgfirebasetools/tool.go
+++ b/tools/sgfirebasetools/tool.go
@@ -39,6 +39,7 @@ func DeployPreview(ctx context.Context, opts DeployPreviewOptions) (string, erro
 		"hosting:channel:deploy",
 		opts.ChannelID,
 		"--project", opts.Project,
+		"--only", opts.Project,
 		"--json",
 	}
 	if opts.Site != "" {


### PR DESCRIPTION
This limits the deploy to only use the hosting:<project-name> of the provided project from the firebase.json file.

More reading about `--only` https://firebase.google.com/docs/cli/#partial_deploys

When writing this I realise that this might be a breaking change. I'm not suer how it will fallback if no project name is specified in the firebase.json file. I will have to investigate that before moving on with this. Changing this into a draft instead, for now.