### PR TITLE
feat(golangcilint): bump to v1.51.0

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.50.1"
+	version = "1.51.0"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Adds support for Go 1.20 among other things.
https://github.com/golangci/golangci-lint/releases/tag/v1.51.0