### PR TITLE
fix(golangcilint): bump to v1.51.0

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.51.0"
+	version = "1.51.1"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Minor fix version. Changelog can be found here:
https://github.com/golangci/golangci-lint/releases/tag/v1.51.1