### PR TITLE
feat(sggolicenses): add command for checking license in a specific path

### DIFF
--- a/tools/sggolicenses/tools.go
+++ b/tools/sggolicenses/tools.go
@@ -25,6 +25,38 @@ func Command(ctx context.Context, args ...string) *exec.Cmd {
 	return sg.Command(ctx, sg.FromBinDir(name), args...)
 }
 
+// Check for disallowed types of Go licenses in a specific directory.
+// By default, Google's forbidden and restricted types are disallowed.
+func CheckDir(ctx context.Context, directory string, disallowedTypes ...string) error {
+	args := []string{
+		"check",
+		".",
+		"--skip_headers",
+		"--ignore",
+		"github.com/einride",
+		"--ignore",
+		"go.einride.tech",
+	}
+	if len(disallowedTypes) > 0 {
+		args = append(args, "--disallowed_types="+strings.Join(disallowedTypes, ","))
+	} else {
+		args = append(args, "--disallowed_types=forbidden,restricted")
+	}
+	cmd := Command(ctx, args...)
+	cmd.Dir = filepath.Dir(directory)
+	// go-licenses tries to exclude standard library packages by checking if they are prefixed
+	// with `runtime.GOROOT()`. However, if the go-licenses tool is not run with a GOROOT environment variable,
+	// that call will return the GOROOT path used during build time of go-licenses. This typically works on Linux,
+	// but on macOS with Homebrew, the GOROOT is version prefixed, which breaks as soon as Go is upgraded.
+	// For example: /opt/homebrew/Cellar/go/1.19.4/libexec
+	//
+	// As a workaround, add the GOROOT environment variable to the result of `runtime.GOROOT()` called here.
+	// This should work as the Sage binary is built on the same machine that executes it.
+	// See: https://github.com/google/go-licenses/issues/149
+	cmd.Env = append(cmd.Env, fmt.Sprintf("GOROOT=%s", runtime.GOROOT()))
+	return cmd.Run()
+}
+
 // Check for disallowed types of Go licenses.
 // By default, Google's forbidden and restricted types are disallowed.
 func Check(ctx context.Context, disallowedTypes ...string) error {


### PR DESCRIPTION
In projects where there are no Go files in the same folder as the go.mod file (often because one wants to keep the go.mod in the root of the project to keep git tagging simple) the license checker fails as it expects go source files where it is running.
So we add a new CheckInDirectory target which uses a specified directory instead of a go.mod file
