### PR TITLE
bump versions feb 2023

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.41.0"
+	version = "1.42.0"
 	name    = "api-linter"
 )
 

--- a/tools/sgbuf/tools.go
+++ b/tools/sgbuf/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "1.9.0"
+	version = "1.14.0"
 	name    = "buf"
 )
 

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.51.1"
+	version = "1.51.2"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
- feat(buf): bump to 1.14.0
- feat(api-linter): bump to 1.42.0
- feat(golangci-lint): bump to v1.51.2
