### PR TITLE
feat: add `CommandContext` to exec

### DIFF
--- a/sg/exec.go
+++ b/sg/exec.go
@@ -24,8 +24,7 @@ func ContextWithEnv(ctx context.Context, env ...string) context.Context {
 
 // Command should be used when returning exec.Cmd from tools to set opinionated standard fields.
 func Command(ctx context.Context, path string, args ...string) *exec.Cmd {
-	// TODO: use exec.CommandContext when we have determined there are no side-effects.
-	cmd := exec.Command(path)
+	cmd := exec.CommandContext(ctx, path)
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Dir = FromGitRoot(".")
 	cmd.Env = os.Environ()


### PR DESCRIPTION
It's beneficial to be able set a timeout for some commands using sage. 
~This PR adds a new `CommandContext` function to exec package to allow for that
Didn't add context to `Command` function to avoid any side affect on already available tools.~

This PR uses `exec.CommandContext` instead of `exec.Command`. 
The provided context is used to interrupt the process (by calling cmd.Cancel or os.Process.Kill) if the context becomes done before the command completes on its own ([reference](https://pkg.go.dev/os/exec#CommandContext))