### PR TITLE
fix: upgrade dbt-core to 1.4.0

### DIFF
--- a/tools/sgdbt/tools.go
+++ b/tools/sgdbt/tools.go
@@ -13,8 +13,7 @@ import (
 
 const (
 	name                   = "dbt"
-	bigqueryPackageVersion = "1.3.0"
-	pytzVersion            = "2022.7.1"
+	bigqueryPackageVersion = "1.4.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
@@ -52,16 +51,6 @@ func PrepareCommand(ctx context.Context) error {
 		pip,
 		"install",
 		fmt.Sprintf("dbt-bigquery==%s", bigqueryPackageVersion),
-	).Run(); err != nil {
-		return err
-	}
-	// install pytz since dbt needs it but doesn't list it as a dependency
-	// https://github.com/dbt-labs/dbt-core/issues/7075
-	if err := sg.Command(
-		ctx,
-		pip,
-		"install",
-		fmt.Sprintf("pytz==%s", pytzVersion),
 	).Run(); err != nil {
 		return err
 	}

--- a/tools/sgsqlfluff/tools.go
+++ b/tools/sgsqlfluff/tools.go
@@ -14,8 +14,7 @@ import (
 const (
 	name               = "sqlfluff"
 	version            = "1.4.5"
-	dbtBigQueryVersion = "1.3.0"
-	pytzVersion        = "2022.7.1"
+	dbtBigQueryVersion = "1.4.0"
 )
 
 // Command runs the sqlfluff CLI.
@@ -75,16 +74,6 @@ func PrepareCommand(ctx context.Context) error {
 		pip,
 		"install",
 		fmt.Sprintf("sqlfluff-templater-dbt==%s", version),
-	).Run(); err != nil {
-		return err
-	}
-	// install pytz since dbt needs it but doesn't list it as a dependency
-	// https://github.com/dbt-labs/dbt-core/issues/7075
-	if err := sg.Command(
-		ctx,
-		pip,
-		"install",
-		fmt.Sprintf("pytz==%s", pytzVersion),
 	).Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
if approved, this PR will:

- Upgrade dbt core to `1.4.0`.
- Remove the temporary workaround where `pytz` is explicitly installed. Not needed anymore as this is fixed in dbt core https://github.com/dbt-labs/dbt-core/pull/7077