### PR TITLE
feat(cloud-endpoints): bump ESPv2 to 2.42.0

### DIFF
--- a/tools/sgcloudendpoints/tools.go
+++ b/tools/sgcloudendpoints/tools.go
@@ -18,7 +18,7 @@ import (
 )
 
 // espVersion is the version of ESPv2 used for building images.
-const espVersion = "2.37.0"
+const espVersion = "2.42.0"
 
 //go:embed Dockerfile
 var dockerfile []byte


### PR DESCRIPTION
Updated version of Envoy, Go, and various bugfixes.
