### PR TITLE
chore: bump sqlfluff from 1.4.5 to 2.0.0a4

### DIFF
--- a/tools/sgsqlfluff/tools.go
+++ b/tools/sgsqlfluff/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name               = "sqlfluff"
-	version            = "1.4.5"
+	version            = "2.0.0a4"
 	dbtBigQueryVersion = "1.4.0"
 )
 


### PR DESCRIPTION
Fixes a problem fixed in https://github.com/sqlfluff/sqlfluff/pull/4317
causing all sqlfluff runs to fail due to the same fix pushed here
https://github.com/einride/sage/pull/399/files
