### PR TITLE
fix(ko): bump to v0.13.0

### DIFF
--- a/tools/sgko/tools.go
+++ b/tools/sgko/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "ko"
-	version = "0.12.0"
+	version = "0.13.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
Changelog can be found here:
https://github.com/ko-build/ko/releases/tag/v0.13.0