### PR TITLE
fix(protoc): bump to v22.2

### DIFF
--- a/tools/sgprotoc/tools.go
+++ b/tools/sgprotoc/tools.go
@@ -12,7 +12,7 @@ import (
 	"go.einride.tech/sage/sgtool"
 )
 
-const version = "3.19.5"
+const version = "22.2"
 
 //nolint:gochecknoglobals
 var commandPath string


### PR DESCRIPTION
Recently, a fix was merged (https://github.com/einride/sage/pull/401) to use arm64 binaries when available. In protobuf v3.19.5, the binary for OSX arm64 is not available (see [here](https://github.com/protocolbuffers/protobuf/releases/tag/v3.19.5)), and any command using protoc fails when run locally. It does exisit in the [latest release](https://github.com/protocolbuffers/protobuf/releases/tag/v22.2), so bumping the version should fix the issue.

If approved, this PR will:
- Bump protobuf version from v3.19.5 to v22.2

Open to alternative fix suggestions. 