### PR TITLE
feat(actions): default to Go 1.20

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -15,7 +15,7 @@ inputs:
   go-version:
     description: The Go version to download (if necessary) and use. Supports semver spec and ranges.
     required: false
-    default: 1.19
+    default: '1.20'
 
   check-latest:
     description: If true, checks whether the cached go version is the latest, if not then downloads the latest. Useful when you need to use the latest version.


### PR DESCRIPTION
Workflows using the setup-sage action will now default to Go 1.20 instead of Go 1.19.