### PR TITLE
fix(sgmvn): change remote for downloading mvn

### DIFF
--- a/tools/sgmvn/tools.go
+++ b/tools/sgmvn/tools.go
@@ -12,7 +12,7 @@ import (
 
 const (
 	name    = "mvn"
-	version = "3.8.7"
+	version = "3.8.8"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgmvn/tools.go
+++ b/tools/sgmvn/tools.go
@@ -27,7 +27,7 @@ func PrepareCommand(ctx context.Context) error {
 	if err := sgtool.FromRemote(
 		ctx,
 		fmt.Sprintf(
-			"https://dlcdn.apache.org/maven/maven-3/%s/binaries/apache-maven-%s-bin.tar.gz",
+			"https://archive.apache.org/dist/maven/maven-3/%s/binaries/apache-maven-%s-bin.tar.gz",
 			version,
 			version,
 		),


### PR DESCRIPTION
archive.apache.org is a long-term archive, whereas dlcdn.apache.org has a limited selection of latest
 releases. After 3.8.8 was released, 3.8.7 was removed from the latter server.