### PR TITLE
fix(golangcilint): bump to v1.52.2

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.52.1"
+	version = "1.52.2"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Minor fix:
https://github.com/golangci/golangci-lint/releases/tag/v1.52.2