### PR TITLE
feat: bump default Go version to 1.20.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sagefile := $(abspath $(cwd)/.sage/bin/sagefile)
 go := $(shell command -v go 2>/dev/null)
 export GOWORK ?= off
 ifndef go
-SAGE_GO_VERSION ?= 1.18.4
+SAGE_GO_VERSION ?= 1.20.2
 export GOROOT := $(abspath $(cwd)/.sage/tools/go/$(SAGE_GO_VERSION)/go)
 export PATH := $(PATH):$(GOROOT)/bin
 go := $(GOROOT)/bin/go

--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -15,7 +15,7 @@ import (
 	"go.einride.tech/sage/internal/strcase"
 )
 
-const defaultGoVersion = "1.18.4"
+const defaultGoVersion = "1.20.2"
 
 type Makefile struct {
 	Namespace     interface{}


### PR DESCRIPTION
Same version as the github action uses
