### PR TITLE
feat: add sqlfluff configuration file

### DIFF
--- a/tools/sgsqlfluff/.sqlfluff
+++ b/tools/sgsqlfluff/.sqlfluff
@@ -1,0 +1,18 @@
+[sqlfluff]
+dialect = bigquery
+templater = jinja
+sql_file_exts = .sql
+max_line_length = 120
+
+[sqlfluff:templater]
+unwrap_wrapped_queries = true
+
+[sqlfluff:templater:jinja]
+apply_dbt_builtins = true
+load_macros_from_path = ../../../data-mesh/dbt/macros
+
+[sqlfluff:indentation]
+tab_space_size = 2
+
+[sqlfluff:rules:L010]
+capitalisation_policy = upper


### PR DESCRIPTION
This PR will make it possible to have a .sqlfluff config file here instead of having one in each repo using it. If a repository dont wanna use this config file it is possible to create a own in the data-mesh/dbt folder that will overwrite this one. 