### PR TITLE
feat: ignore words with contradictory spellings

### DIFF
--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -238,6 +238,9 @@ linters-settings:
 
   misspell:
     locale: US
+    ignore-words:
+      - cancelled
+      - cancelling
 
   prealloc:
     simple: true


### PR DESCRIPTION
The word cancelled is spelled differently between GB English and US English.

The Google API linter specifically chooses the GB spelling and this causes issues
when both linters are used together, which is the vast majority of Einride services.

An example of this contradiction is shown below:

```
--- API LINTER
example.proto:1:5: Prefer "CANCELLED" over "CANCELED" for state names (core::0216::value-synonyms)
...
--- MISSPELL
example_test.go:1:59: `CANCELLED` is a misspelling of `CANCELED` (misspell)
```

We have the option to configure this on the misspell linter so it makes the most
sense to do the change there.
