### PR TITLE
feat(gosemanticrelease): bump to v2.27.1

### DIFF
--- a/tools/sggosemanticrelease/tools.go
+++ b/tools/sggosemanticrelease/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "go-semantic-release"
-	version = "2.25.0"
+	version = "2.27.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
Changelog here:
https://github.com/go-semantic-release/semantic-release/releases/tag/v2.27.1