### PR TITLE
fix(actions): delegate cache to setup-go action

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -41,17 +41,7 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
         check-latest: ${{ inputs.check-latest }}
-
-    - name: Cache Go modules
-      if: ${{ inputs.disableCache != 'true' }}
-      uses: actions/cache@v3
-      with:
-        path: |
-          ~/.cache/go-build
-          ~/go/pkg/mod
-        key: ${{ runner.os }}-go-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
-        restore-keys: |
-          ${{ runner.os }}-go-${{ inputs.cacheKey }}-${{ inputs.go-version }}-
+        cache: ${{ inputs.disableCache != 'true' }}
 
     - name: Cache sage folders
       if: ${{ inputs.disableCache != 'true' }}


### PR DESCRIPTION
Since v4 of setup-go, caching of the root go module is enabled by default. This means we are caching the modules twice and also causing some conflict on restore.

Removing our caching of Go modules should hopefully fix this.