### PR TITLE
bump dbt to 1.5.1

### DIFF
--- a/tools/sgdbt/tools.go
+++ b/tools/sgdbt/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name                   = "dbt"
-	bigqueryPackageVersion = "1.4.2"
+	bigqueryPackageVersion = "1.5.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgsqlfluff/tools.go
+++ b/tools/sgsqlfluff/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name               = "sqlfluff"
-	version            = "2.0.0a4"
+	version            = "2.1.1"
 	dbtBigQueryVersion = "1.5.1"
 )
 

--- a/tools/sgsqlfluff/tools.go
+++ b/tools/sgsqlfluff/tools.go
@@ -14,7 +14,7 @@ import (
 const (
 	name               = "sqlfluff"
 	version            = "2.0.0a4"
-	dbtBigQueryVersion = "1.4.0"
+	dbtBigQueryVersion = "1.5.1"
 )
 
 // Command runs the sqlfluff CLI.


### PR DESCRIPTION
Bumps dbt to latest 1.5.1 in sgdbt as well as sgsqlfluff. Furthermore, bumps sqlfluff to latest 2.1.1.