### PR TITLE
feat(sgbalena): use local installed balena binary if exists

### DIFF
--- a/tools/sgbalenacli/tools.go
+++ b/tools/sgbalenacli/tools.go
@@ -54,6 +54,13 @@ func Whoami(ctx context.Context) (WhoamiInfo, error) {
 }
 
 func PrepareCommand(ctx context.Context) error {
+	// Special case: use local balena CLI if available.
+	if binary, err := exec.LookPath("balena"); err == nil {
+		if _, err := sgtool.CreateSymlink(binary); err != nil {
+			return err
+		}
+		return nil
+	}
 	binDir := sg.FromToolsDir(toolName, version)
 	binary := filepath.Join(binDir, toolName, binaryName)
 	hostOS := runtime.GOOS


### PR DESCRIPTION
Similar to how gcloud and docker is handled; if the binary can be found
in users path, use it directly.

This makes it possible to use sgbalena on NixOS.
