### PR TITLE
security(espv2): Bump Espv2 Version

### DIFF
--- a/tools/sgcloudendpoints/tools.go
+++ b/tools/sgcloudendpoints/tools.go
@@ -18,7 +18,7 @@ import (
 )
 
 // espVersion is the version of ESPv2 used for building images.
-const espVersion = "2.42.0"
+const espVersion = "2.43.0"
 
 //go:embed Dockerfile
 var dockerfile []byte


### PR DESCRIPTION
A recent advisory from google shows an authentication bypass in ESPv2 which could affect us. https://github.com/GoogleCloudPlatform/esp-v2/security/advisories/GHSA-6qmp-9p95-fc5f