### PR TITLE
fix(cache): hierarchically restore Sage cache

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -5,7 +5,7 @@ inputs:
   cacheKey:
     description: Custom cache key used
     required: false
-    default: ${{ github.workflow }}.${{ github.job }}
+    default: cachekey
 
   disableCache:
     description: Disable cache
@@ -50,6 +50,10 @@ runs:
         path: |
           ./.sage/tools
           ./.sage/bin
-        key: ${{ runner.os }}-sage-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('./.sage/go.sum') }}
+        key: ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('./.sage/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-sage-${{ inputs.cacheKey }}-${{ inputs.go-version }}-
+          ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-
+          ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-
+          ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-
+          ${{ runner.os }}-sage-${{ github.workflow }}-
+          ${{ runner.os }}-sage-


### PR DESCRIPTION
If there is a cache miss, we now walk up the tree until we find a hit. Even if the hit is not a perfect match, it is at least (probably...) better than a cache miss.

Since this uses a new cache key, it will be a cache miss the first time after this change is merged.