### PR TITLE
fix(tools)!: upgreade sgcloudsqlproxy to 2.3.0 (breaking change) 

### DIFF
--- a/tools/sgcloudsqlproxy/tool.go
+++ b/tools/sgcloudsqlproxy/tool.go
@@ -12,8 +12,8 @@ import (
 )
 
 const (
-	version    = "1.33.1"
-	binaryName = "cloud_sql_proxy"
+	version    = "2.3.0"
+	binaryName = "cloud-sql-proxy"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
@@ -25,12 +25,12 @@ func PrepareCommand(ctx context.Context) error {
 	binDir := sg.FromToolsDir(binaryName, version)
 	binary := filepath.Join(binDir, binaryName)
 	filename := fmt.Sprintf(
-		"cloud_sql_proxy.%s.%s",
+		"cloud-sql-proxy.%s.%s",
 		runtime.GOOS,
 		runtime.GOARCH,
 	)
 	binURL := fmt.Sprintf(
-		"https://storage.googleapis.com/cloudsql-proxy/v%s/%s",
+		"https://storage.googleapis.com/cloud-sql-connectors/cloud-sql-proxy/v%s/%s",
 		version,
 		filename,
 	)


### PR DESCRIPTION
Beaking change as one will need to replace the cmd parameter from
'cloud_sql_proxy -instances=myproject:myregion:myinstance=tcp:5432 --enable_iam_login'
to:
'cloud-sql-proxy myproject:myregion:myinstance --port 5432 --auto-iam-authn'

---

## Reason for update:

Perhaps this can help the build error that shows up recently from time to time?

```
[backend:deploy-dev] migrating database...
[backend:deploy-dev] 2023/06/16 08:31:09 current FDs rlimit set to 65536, wanted limit is 8500. Nothing to do here.
[backend:deploy-dev] 2023/06/16 08:31:09 using credential file for authentication; 
[backend:deploy-dev] Running golang migrate...
[backend:deploy-dev] error: dial tcp [::1]:5432: connect: connection refused
[backend:deploy-dev] could not migrate database: exit status 1
```

As this error seems happened in the db migration step and a proxy connection is needed for that.

---

The download UIL might be changed for the new version, I hope I setup it up correctly but you can help me double check, thank you
https://cloud.google.com/sql/docs/mysql/connect-auth-proxy#macos-64-bit
