### PR TITLE
fix(sgsqlfluff): pin dbt-core to 1.5.1 in sgsqlfluff

### DIFF
--- a/tools/sgsqlfluff/tools.go
+++ b/tools/sgsqlfluff/tools.go
@@ -66,6 +66,8 @@ func PrepareCommand(ctx context.Context) error {
 		pip,
 		"install",
 		fmt.Sprintf("dbt-bigquery==%s", dbtBigQueryVersion),
+		// TODO: remove when sqlfluff is bumped https://github.com/sqlfluff/sqlfluff/issues/4930
+		fmt.Sprintf("dbt-core==%s", "1.5.1"),
 	).Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
SQLFluff 2.1.1 is not compatible with dbt-core 1.5.2 which was released on Thursday. As we only pin dbt-bigquery we download dbt-core 1.5.2 resulting in SQLFluff errors.