### PR TITLE
summer of 2023 bump deps

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.42.0"
+	version = "1.52.3"
 	name    = "api-linter"
 )
 

--- a/tools/sgbalenacli/tools.go
+++ b/tools/sgbalenacli/tools.go
@@ -15,7 +15,7 @@ import (
 const (
 	toolName   = "balena-cli"
 	binaryName = "balena"
-	version    = "v15.0.3"
+	version    = "v16.6.3"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgbuf/tools.go
+++ b/tools/sgbuf/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "1.14.0"
+	version = "1.23.1"
 	name    = "buf"
 )
 

--- a/tools/sgconvco/tools.go
+++ b/tools/sgconvco/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "convco"
-	version = "0.3.15"
+	version = "0.4.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggh/tools.go
+++ b/tools/sggh/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "gh"
-	version = "2.15.0"
+	version = "2.31.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggolangmigrate/tools.go
+++ b/tools/sggolangmigrate/tools.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "4.15.2"
+	version = "4.16.2"
 	name    = "migrate"
 )
 

--- a/tools/sggoreleaser/tools.go
+++ b/tools/sggoreleaser/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "goreleaser"
-	version = "1.11.5"
+	version = "1.19.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgko/tools.go
+++ b/tools/sgko/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "ko"
-	version = "0.13.0"
+	version = "0.14.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgshellcheck/tools.go
+++ b/tools/sgshellcheck/tools.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	version = "0.8.0"
+	version = "0.9.0"
 	name    = "shellcheck"
 )
 

--- a/tools/sgshfmt/tools.go
+++ b/tools/sgshfmt/tools.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	version = "3.4.2"
+	version = "3.7.0"
 	name    = "shfmt"
 )
 

--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version    = "1.3.7"
+	version    = "1.5.2"
 	binaryName = "terraform"
 )
 

--- a/tools/sgtfsec/tools.go
+++ b/tools/sgtfsec/tools.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "1.27.6"
+	version = "1.28.1"
 	name    = "tfsec"
 )
 

--- a/tools/sgyamlfmt/tools.go
+++ b/tools/sgyamlfmt/tools.go
@@ -19,7 +19,7 @@ var defaultConfig []byte
 
 const (
 	name              = "yamlfmt"
-	version           = "0.6.0"
+	version           = "0.9.0"
 	defaultConfigName = ".yamlfmt"
 )
 

--- a/tools/sgyq/tools.go
+++ b/tools/sgyq/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "yq"
-	version = "4.27.5"
+	version = "4.34.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
- feat(deps): bump api-linter to v1.52.3
- feat(deps): bump balena-cli to v16.6.3
- feat(deps): bump buf to v1.23.1
- feat(deps): bump convco to v0.4.0
- feat(deps): bump gh to 2.31.0
- feat(deps): bump golang-migrate to v4.16.2
- feat(deps): bump go-releaser to v1.19.1
- feat(deps): bump ko to v0.14.1
- feat(deps): bump shellcheck to v0.9.0
- feat(deps): bump shfmt to v3.7.0
- feat(deps): bump terraform to v1.5.2
- feat(deps): bump tfsec to v1.28.1
- feat(deps): bump yamlfmt to v0.9.0
- feat(deps): bump yq to v4.34.1
