### PR TITLE
feat(ghcomment): add GH TF comment with summary

### DIFF
--- a/tools/sgterraform/tfplan.go
+++ b/tools/sgterraform/tfplan.go
@@ -1,0 +1,126 @@
+package sgterraform
+
+// This file contains needed functionality and definitions from github.com/hashicorp/terraform-json to parse the
+// tf json plan.
+
+// Plan contains a simplified definition of the json generated when using the -json flag for terraform plan.
+// It only includes the fields needed to generate the plan summery used in CommentOnPRWithPlanSummarized.
+// The full plan definition can be found in github.com/hashicorp/terraform-json.
+type Plan struct {
+	ResourceChanges []*struct {
+		// The resource type, example: "aws_instance" for aws_instance.foo.
+		Type string `json:"type,omitempty"`
+
+		// The resource name, example: "foo" for aws_instance.foo.
+		Name string `json:"name,omitempty"`
+
+		// The data describing the change that will be made to this object.
+		Change *struct {
+			// The action to be carried out by this change.
+			Actions Actions `json:"actions,omitempty"`
+		} `json:"change,omitempty"`
+	} `json:"resource_changes,omitempty"`
+}
+
+// Action is a valid action type for a resource change.
+//
+// Note that a singular Action is not telling of a full resource
+// change operation. Certain resource actions, such as replacement,
+// are a composite of more than one type. See the Actions type and
+// its helpers for more information.
+type Action string
+
+const (
+	// ActionNoop denotes a no-op operation.
+	ActionNoop Action = "no-op"
+
+	// ActionCreate denotes a create operation.
+	ActionCreate Action = "create"
+
+	// ActionRead denotes a read operation.
+	ActionRead Action = "read"
+
+	// ActionUpdate denotes an update operation.
+	ActionUpdate Action = "update"
+
+	// ActionDelete denotes a delete operation.
+	ActionDelete Action = "delete"
+)
+
+// Actions denotes a valid change type.
+type Actions []Action
+
+// NoOp is true if this set of Actions denotes a no-op.
+func (a Actions) NoOp() bool {
+	if len(a) != 1 {
+		return false
+	}
+
+	return a[0] == ActionNoop
+}
+
+// Create is true if this set of Actions denotes creation of a new
+// resource.
+func (a Actions) Create() bool {
+	if len(a) != 1 {
+		return false
+	}
+
+	return a[0] == ActionCreate
+}
+
+// Read is true if this set of Actions denotes a read operation only.
+func (a Actions) Read() bool {
+	if len(a) != 1 {
+		return false
+	}
+
+	return a[0] == ActionRead
+}
+
+// Update is true if this set of Actions denotes an update operation.
+func (a Actions) Update() bool {
+	if len(a) != 1 {
+		return false
+	}
+
+	return a[0] == ActionUpdate
+}
+
+// Delete is true if this set of Actions denotes resource removal.
+func (a Actions) Delete() bool {
+	if len(a) != 1 {
+		return false
+	}
+
+	return a[0] == ActionDelete
+}
+
+// DestroyBeforeCreate is true if this set of Actions denotes a
+// destroy-before-create operation. This is the standard resource
+// replacement method.
+func (a Actions) DestroyBeforeCreate() bool {
+	if len(a) != 2 {
+		return false
+	}
+
+	return a[0] == ActionDelete && a[1] == ActionCreate
+}
+
+// CreateBeforeDestroy is true if this set of Actions denotes a
+// create-before-destroy operation, usually the result of replacement
+// to a resource that has the create_before_destroy lifecycle option
+// set.
+func (a Actions) CreateBeforeDestroy() bool {
+	if len(a) != 2 {
+		return false
+	}
+
+	return a[0] == ActionCreate && a[1] == ActionDelete
+}
+
+// Replace is true if this set of Actions denotes a valid replacement
+// operation.
+func (a Actions) Replace() bool {
+	return a.DestroyBeforeCreate() || a.CreateBeforeDestroy()
+}

--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -1,12 +1,16 @@
 package sgterraform
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"fmt"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sort"
 	"strings"
+	"text/tabwriter"
 
 	"go.einride.tech/sage/sg"
 	"go.einride.tech/sage/sgtool"
@@ -59,6 +63,54 @@ func CommentOnPullRequestWithPlan(ctx context.Context, prNumber, environment, pl
 	)
 }
 
+func CommentOnPRWithPlanSummarized(ctx context.Context, prNumber, environment, planFilePath string) *exec.Cmd {
+	cmd := Command(
+		ctx,
+		"show",
+		"-no-color",
+		filepath.Base(planFilePath),
+	)
+	cmd.Dir = filepath.Dir(planFilePath)
+	cmd.Stdout = nil
+	out, err := cmd.Output()
+	if err != nil {
+		sg.Logger(ctx).Fatal(err)
+	}
+	statusIcon, summary := getCommentSummary(ctx, planFilePath)
+	comment := fmt.Sprintf(`
+<div>
+<img
+  align="right"
+  width="120"
+  src="https://upload.wikimedia.org/wikipedia/commons/0/04/Terraform_Logo.svg" />
+<h2>%s Terraform Plan (%s) %s</h2>
+</div>
+<pre><code>%s</code></pre>
+<details>
+<summary>Details (Click me)</summary>
+<p>
+
+%s
+
+</p>
+</details>
+`,
+		statusIcon,
+		environment,
+		statusIcon,
+		summary,
+		fmt.Sprintf("```"+"hcl\n%s\n"+"```", strings.TrimSpace(string(out))))
+	return sgghcomment.Command(
+		ctx,
+		"--pr",
+		prNumber,
+		"--signkey",
+		environment,
+		"--comment",
+		comment,
+	)
+}
+
 func PrepareCommand(ctx context.Context) error {
 	hostOS := runtime.GOOS
 	hostArch := runtime.GOARCH
@@ -83,4 +135,111 @@ func PrepareCommand(ctx context.Context) error {
 	}
 
 	return nil
+}
+
+func getCommentSummary(ctx context.Context, planFilePath string) (statusIcon, summary string) {
+	var jsonBuf bytes.Buffer
+	cmdJSON := Command(
+		ctx,
+		"show",
+		"-no-color",
+		"-json",
+		filepath.Base(planFilePath),
+	)
+	cmdJSON.Dir = filepath.Dir(planFilePath)
+	cmdJSON.Stdout = &jsonBuf
+	if err := cmdJSON.Run(); err != nil {
+		sg.Logger(ctx).Fatal(err)
+	}
+
+	var jsonPlan Plan
+	err := json.Unmarshal(jsonBuf.Bytes(), &jsonPlan)
+	if err != nil {
+		sg.Logger(ctx).Fatal(err)
+	}
+
+	create := TfChange{actionName: "Create", changes: make(map[string]int), actionCount: 0}
+	destroy := TfChange{actionName: "Destroy", changes: make(map[string]int), actionCount: 0}
+	update := TfChange{actionName: "Update", changes: make(map[string]int), actionCount: 0}
+	replace := TfChange{actionName: "Replace", changes: make(map[string]int), actionCount: 0}
+	for _, res := range jsonPlan.ResourceChanges {
+		actions := res.Change.Actions
+		resourceType := res.Type
+		switch {
+		case actions.Create():
+			create.add(resourceType)
+		case actions.Delete():
+			destroy.add(resourceType)
+		case actions.Update():
+			update.add(resourceType)
+		case actions.Replace():
+			replace.add(resourceType)
+		case
+			actions.NoOp(),
+			actions.Read():
+			// Do nothing
+			continue
+		default:
+			sg.Logger(ctx).Fatal(fmt.Errorf("unable to determine resource operation: %v", res))
+		}
+	}
+
+	statusIcon = ":green_circle:"
+	if update.actionCount > 0 {
+		statusIcon = ":orange_circle:"
+	}
+	if destroy.actionCount > 0 || replace.actionCount > 0 {
+		statusIcon = ":red_circle:"
+	}
+
+	summary = fmt.Sprintf(`
+Plan Summary: %d to create, %d to update, %d to replace, %d to destroy.
+
+%s
+`,
+		create.actionCount,
+		update.actionCount,
+		replace.actionCount,
+		destroy.actionCount,
+		mapToHTMLList([]TfChange{create, destroy, update, replace}),
+	)
+
+	return statusIcon, summary
+}
+
+type TfChange struct {
+	actionName  string
+	actionCount int
+	changes     map[string]int
+}
+
+func (t *TfChange) add(resourceType string) {
+	t.actionCount++
+	t.changes[resourceType]++
+}
+
+func mapToHTMLList(input []TfChange) string {
+	if len(input) == 0 {
+		return ""
+	}
+	var htmlList string
+	for _, v := range input {
+		if v.actionCount == 0 {
+			continue
+		}
+		keys := make([]string, 0, len(input))
+		for k := range v.changes {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		var b bytes.Buffer
+		w := tabwriter.NewWriter(&b, 0, 0, 3, '.', tabwriter.FilterHTML)
+		htmlList += fmt.Sprintf("<b>%s (%d):</b><ul>", v.actionName, v.actionCount)
+		for _, key := range keys {
+			fmt.Fprintf(w, "%s\t%d\n", key, v.changes[key])
+		}
+		w.Flush()
+		htmlList += b.String() + "</ul>"
+	}
+	return htmlList
 }


### PR DESCRIPTION
Iterated version of the TF plan PR comment functionality created by @alethenorio in the [gcp-projects repo](https://github.com/einride/gcp-projects/blob/master/.sage/cdktf.go#L361). Difference between this and the existing comment functionality is that it shows an overall summary and a list of type of resources being changed grouped by action. See example of output in image below. The full HCL plan is also included but collapsed by default. The tfplan file contains simplified TF json definitions lifted from the [github.com/hashicorp/terraform-json](github.com/hashicorp/terraform-json) repo.

![image](https://github.com/einride/sage/assets/44864447/4e2a65ad-8298-4bae-adc8-35defd50adc2)
