### PR TITLE
feat(sgapilinter): bump to version v1.52.4

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.52.3"
+	version = "1.52.4"
 	name    = "api-linter"
 )
 


### PR DESCRIPTION
Includes fixes, see https://github.com/googleapis/api-linter/releases/tag/v1.52.4
