### PR TITLE
feat: add trivy tool

### DIFF
--- a/tools/sgtfsec/tools.go
+++ b/tools/sgtfsec/tools.go
@@ -1,3 +1,6 @@
+// Deprecated: tfsec is deprecated and has been replaced by trivy.
+//
+// See sgtrivy package for a replacement.
 package sgtfsec
 
 import (

--- a/tools/sgtrivy/tools.go
+++ b/tools/sgtrivy/tools.go
@@ -1,0 +1,99 @@
+package sgtrivy
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"go.einride.tech/sage/sg"
+	"go.einride.tech/sage/sgtool"
+)
+
+//go:embed trivyignore
+var defaultConfig []byte
+
+const (
+	version = "0.43.1"
+	name    = "trivy"
+)
+
+func defaultConfigPath() string {
+	return sg.FromToolsDir(name, ".trivyignore")
+}
+
+// CheckTerraformCommand checks terraform configuration on the given dir
+// for any known security misconfigurations.
+// It includes a default .trivyignore.yaml which can be
+// overridedn by setting a .trivyignore.yaml in the git root.
+func CheckTerraformCommand(ctx context.Context, dir string) *exec.Cmd {
+	args := []string{
+		"config",
+		"--exit-code",
+		"1",
+		dir,
+	}
+
+	configPath := sg.FromGitRoot(".trivyignore")
+	if _, err := os.Lstat(configPath); errors.Is(err, os.ErrNotExist) {
+		configPath = defaultConfigPath()
+	}
+	args = append(args, "--ignorefile", configPath)
+
+	return Command(ctx, args...)
+}
+
+func Command(ctx context.Context, args ...string) *exec.Cmd {
+	sg.Deps(ctx, PrepareCommand)
+	return sg.Command(ctx, sg.FromBinDir(name), args...)
+}
+
+func PrepareCommand(ctx context.Context) error {
+	toolDir := sg.FromToolsDir(name, version)
+	binary := filepath.Join(toolDir, name)
+	var goos, goarch string
+	switch runtime.GOOS {
+	case "linux":
+		goos = "Linux"
+	case "darwin":
+		goos = "macOS"
+	default:
+		return fmt.Errorf("unsupported OS in sgtrivy package %s", runtime.GOOS)
+	}
+	switch runtime.GOARCH {
+	case sgtool.AMD64:
+		goarch = "64bit"
+	case sgtool.Darwin:
+		goarch = "ARM64"
+	default:
+		return fmt.Errorf("unsupported ARCH in sgtrivy package %s", runtime.GOARCH)
+	}
+
+	binURL := fmt.Sprintf(
+		"https://github.com/aquasecurity/trivy/releases/download/v%s/trivy_%s_%s-%s.tar.gz",
+		version,
+		version,
+		goos,
+		goarch,
+	)
+	if err := sgtool.FromRemote(
+		ctx,
+		binURL,
+		sgtool.WithDestinationDir(toolDir),
+		sgtool.WithUntarGz(),
+		sgtool.WithSkipIfFileExists(binary),
+		sgtool.WithSymlink(binary),
+	); err != nil {
+		return fmt.Errorf("unable to download %s: %w", name, err)
+	}
+
+	configPath := defaultConfigPath()
+	if err := os.MkdirAll(filepath.Dir(configPath), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, defaultConfig, 0o600)
+}

--- a/tools/sgtrivy/trivyignore
+++ b/tools/sgtrivy/trivyignore
@@ -1,0 +1,5 @@
+# https://avd.aquasec.com/misconfig/google/storage/avd-gcp-0066/
+# Ignored due to being too strict.
+# Customer managed encryption keys is not something everybody needs and is often a company policy
+# with a lot of backing guidelines and not something one simply toggles on and off.
+AVD-GCP-0066


### PR DESCRIPTION
tfsec is [deprecated](https://github.com/aquasecurity/tfsec/discussions/1994) and the recommendation is to use trivy where the development will continue.
Trivy does a lot more than just Terraform security checking but this commit is limited to replacing tfsec and includes only one helper command to make the transition easy for `sgtfsec` users (API is slightly different).

`sgtrivy` also includes a default .trivyignore which currently only ignores https://avd.aquasec.com/misconfig/google/storage/avd-gcp-0066/ for being too strict.

Lastly, the sgtfsec package has been marked as deprecated.
