### PR TITLE
fix: init sage in repository not working

### DIFF
--- a/main.go
+++ b/main.go
@@ -137,7 +137,8 @@ func resolveSageModulePath(ctx context.Context) (string, error) {
 		return moduleName, nil //nolint:nilerr
 	}
 	var out bytes.Buffer
-	cmd := sg.Command(ctx, "go", "mod", "edit", "-json")
+	cmd := exec.CommandContext(ctx, "go", "mod", "edit", "-json")
+	cmd.Dir = sg.FromGitRoot()
 	cmd.Stdout = &out
 	if err := cmd.Run(); err != nil {
 		return "", err


### PR DESCRIPTION
If merged this PR will fix the init command returning the error `.sage: file exists`. This was caused by a recent addition of `ensureParentDir` to `FromBinDir`. The function `sg.Command` uses `FromBinDir` which causes the .sage directory to already be created when `os.Mkdir` is called in `initSage`
![image](https://github.com/einride/sage/assets/37178947/fe04038f-b79f-4126-a9ce-1648670d65f5)
