### PR TITLE
feat(golangcilint): bump to v1.54.1

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.53.3"
+	version = "1.54.1"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Ensures compatibility with Go v1.21.
