### PR TITLE
fix(sgtrivy): do not scan yaml files

### DIFF
--- a/tools/sgtrivy/tools.go
+++ b/tools/sgtrivy/tools.go
@@ -29,12 +29,14 @@ func defaultConfigPath() string {
 // CheckTerraformCommand checks terraform configuration on the given dir
 // for any known security misconfigurations.
 // It includes a default .trivyignore.yaml which can be
-// overridedn by setting a .trivyignore.yaml in the git root.
+// overridden by setting a .trivyignore.yaml in the git root.
 func CheckTerraformCommand(ctx context.Context, dir string) *exec.Cmd {
 	args := []string{
 		"config",
 		"--exit-code",
 		"1",
+		"--skip-files",
+		"./**/*.yaml",
 		dir,
 	}
 


### PR DESCRIPTION
Trivy has mutliple scanners that look for different file formats and tries to scan them. For example there is a kubernetes scanner that will find certain of our generated yaml files and incorrectly interpret them as kubernetes files. Then it will find Kubernetes security issues with those files.

We should in general only be interested in scanning Terraform files. As a way to prevent trivy from scanning other files, we're here using the --skip-files directive. Examples of how to use --skip-files can be found here: https://github.com/aquasecurity/trivy/blob/6f03c79405e7d3f77dac0c70c265d972a63ba629/docs/docs/configuration/skipping.md?plain=1#L18