### PR TITLE
Add 'build' to commit-lint ignore commit tag

### DIFF
--- a/tools/sgcommitlint/tools.go
+++ b/tools/sgcommitlint/tools.go
@@ -21,7 +21,7 @@ const commitlintFileContent = `module.exports = {
   extends: ["@commitlint/config-conventional"],
   ignores: [
     // ignore dependabot commits
-    (message) => /chore\(deps(-dev)?\): bump/.test(message),
+    (message) => /(chore|build)\(deps(-dev)?\): bump/.test(message),
   ],
 }`
 


### PR DESCRIPTION
Adds 'build' to ignored commit tag for dependabot.

Reason to add is https://github.com/einride/map-go/pull/343

Let me know if there is a better way of doing this :)
