### PR TITLE
feat(sgcloudspanner): bump from 1.5.0 to 1.5.9

### DIFF
--- a/tools/sgcloudspanner/emulator.go
+++ b/tools/sgcloudspanner/emulator.go
@@ -20,7 +20,7 @@ import (
 const (
 	cloudbuildNetwork = "cloudbuild"
 	url               = "gcr.io/cloud-spanner-emulator/emulator"
-	version           = "sha256:35ca79ac580aace9fc72e0741654565e487287022db8de255f50f3971e6dba96" // 1.5.0
+	version           = "sha256:ab53ffefbcb53cea3b893e07c6796ba5df3bc67d1561eeb8efecaec466134f2f" // 1.5.9
 	image             = url + "@" + version
 )
 


### PR DESCRIPTION
The emulator [now supports](https://github.com/GoogleCloudPlatform/cloud-spanner-emulator/releases/tag/v1.5.9) `ON DELETE CASCADE`. This is needed when bumping [`cloud.google.com/go/spanner` to v1.48.0 or beyond](https://github.com/googleapis/google-cloud-go/releases/tag/spanner%2Fv1.48.0) as it now automatically inserts the default `ON DEFAULT NO ACTION` clause (see https://github.com/googleapis/google-cloud-go/pull/8296).

See example failure in iam-go: https://github.com/einride/iam-go/pull/523