### PR TITLE
feat: bump api-linter to 1.57.1

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.52.4"
+	version = "1.57.1"
 	name    = "api-linter"
 )
 


### PR DESCRIPTION
Somehow 1.52.4 version causes a segfault in some localized cases. Cannot replicate the segfault on 1.57.1.