### PR TITLE
fix: rollback version update on api-linter

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.57.1"
+	version = "1.56.1"
 	name    = "api-linter"
 )
 


### PR DESCRIPTION
Updates api-linter to version [v1.56.1](https://github.com/googleapis/api-linter/releases/tag/v1.56.1) as v.[1.57.0](https://github.com/googleapis/api-linter/releases/tag/v1.57.0) introduced a new
requirement for (google.api.field_behavior) = IDENTIFIER to be set on
the name field of a proto resource.

There is a conflict between buf lint and api-linter due to an update to
field_behaviour.proto. An issue has been opened buf as fix is on their side:
https://github.com/bufbuild/buf/issues/2474
