### PR TITLE
feat: update api-linter version to v1.57.1

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.56.1"
+	version = "1.57.1"
 	name    = "api-linter"
 )
 


### PR DESCRIPTION
The issue referenced in #466 has been resolved so we can update the api-linter version again.