### PR TITLE
feat: add action input of cache-dependency-path

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -17,6 +17,11 @@ inputs:
     required: false
     default: '1.21'
 
+  cache-dependency-path:
+    description: Path to the go.sum file(s) to use in caching.
+    required: false
+    default: go.sum
+
   check-latest:
     description: If true, checks whether the cached go version is the latest, if not then downloads the latest. Useful when you need to use the latest version.
     required: false
@@ -42,6 +47,7 @@ runs:
         go-version: ${{ inputs.go-version }}
         check-latest: ${{ inputs.check-latest }}
         cache: ${{ inputs.disableCache != 'true' }}
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}
 
     - name: Cache sage folders
       if: ${{ inputs.disableCache != 'true' }}


### PR DESCRIPTION
By enabling changing the go.sum file(s) to cache on users can configure which subdir is important for their respective actions.

The main use case would most likely be to cache the dependencies of sage in repositories that have many dependencies for sage itself, but it could also be used to cache dependencies in multi module repositories. This is especially useful for sage targets that doesn't run go code but instead a downloaded binary (e.g., Terraform). Some tests of internal repositories halves the time of execution as sage dependency installation is a big part of the runtime of the action.

The default is set to what [setup-go has as default](https://github.com/actions/setup-go#caching-dependency-files-and-build-outputs); the root go.sum in the repository.