### PR TITLE
feat(sgdocker): support apple silicon

### DIFF
--- a/tools/sgdocker/command.go
+++ b/tools/sgdocker/command.go
@@ -34,6 +34,9 @@ func PrepareCommand(ctx context.Context) error {
 	if hostArch == sgtool.AMD64 {
 		hostArch = sgtool.X8664
 	}
+	if hostArch == sgtool.ARM64 {
+		hostArch = "aarch64"
+	}
 	if hostOS == sgtool.Darwin {
 		hostOS = "mac"
 	}


### PR DESCRIPTION
Previous when running from a mac with apple silicon you will get routed too:
`https://download.docker.com/mac/static/stable/arm64/...`

With this change it will correctly route too:
`https://download.docker.com/mac/static/stable/aarch64/...`