### PR TITLE
feat(cloud-endpoints): bump ESPv2 to 2.46.0

### DIFF
--- a/tools/sgcloudendpoints/tools.go
+++ b/tools/sgcloudendpoints/tools.go
@@ -18,7 +18,7 @@ import (
 )
 
 // espVersion is the version of ESPv2 used for building images.
-const espVersion = "2.44.0"
+const espVersion = "2.46.0"
 
 //go:embed Dockerfile
 var dockerfile []byte


### PR DESCRIPTION
Go version updated to 1.20 which should fix CVE-2022-27664:

>  In net/http in Go before 1.18.6 and 1.19.x before 1.19.1, attackers can cause a denial of service because an HTTP/2 connection can hang during closing if shutdown were preempted by a fatal error.