### PR TITLE
Bump commit lint to 18.4.1

### DIFF
--- a/tools/sgcommitlint/tools.go
+++ b/tools/sgcommitlint/tools.go
@@ -12,8 +12,8 @@ import (
 
 const packageJSONContent = `{
   "devDependencies": {
-    "@commitlint/cli": "18.3.0",
-    "@commitlint/config-conventional": "18.3.0"
+    "@commitlint/cli": "18.4.1",
+    "@commitlint/config-conventional": "18.4.0"
   }
 }`
 


### PR DESCRIPTION

Seems like 18.3.0 is not available.

I've seen some builds fail silently because of this.

https://www.npmjs.com/package/commitlint?activeTab=versions
