### PR TITLE
feat: switch markdown formatter

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -11,7 +11,7 @@ import (
 	"go.einride.tech/sage/tools/sggolangcilint"
 	"go.einride.tech/sage/tools/sggolicenses"
 	"go.einride.tech/sage/tools/sggoreview"
-	"go.einride.tech/sage/tools/sgmarkdownfmt"
+	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
 )
 
@@ -58,7 +58,7 @@ func GoLicenses(ctx context.Context) error {
 
 func FormatMarkdown(ctx context.Context) error {
 	sg.Logger(ctx).Println("formatting Markdown files...")
-	return sgmarkdownfmt.Command(ctx, "-w", ".").Run()
+	return sgmdformat.Command(ctx).Run()
 }
 
 func FormatYaml(ctx context.Context) error {

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,87 +1,128 @@
-Contributor Covenant Code of Conduct
-====================================
+# Contributor Covenant Code of Conduct
 
-Our Pledge
-----------
+## Our Pledge
 
-We as members, contributors, and leaders pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, religion, or sexual identity and
+orientation.
 
-We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
 
-Our Standards
--------------
+## Our Standards
 
-Examples of behavior that contributes to a positive environment for our community include:
+Examples of behavior that contributes to a positive environment for our
+community include:
 
--	Demonstrating empathy and kindness toward other people
--	Being respectful of differing opinions, viewpoints, and experiences
--	Giving and gracefully accepting constructive feedback
--	Accepting responsibility and apologizing to those affected by our mistakes, and learning from the experience
--	Focusing on what is best not just for us as individuals, but for the overall community
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
 
 Examples of unacceptable behavior include:
 
--	The use of sexualized language or imagery, and sexual attention or advances of any kind
--	Trolling, insulting or derogatory comments, and personal or political attacks
--	Public or private harassment
--	Publishing others' private information, such as a physical or email address, without their explicit permission
--	Other conduct which could reasonably be considered inappropriate in a professional setting
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
 
-Enforcement Responsibilities
-----------------------------
+## Enforcement Responsibilities
 
-Community leaders are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
 
-Community leaders have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
 
-Scope
------
+## Scope
 
-This Code of Conduct applies within all community spaces, and also applies when an individual is officially representing the community in public spaces. Examples of representing our community include using an official e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
 
-Enforcement
------------
+## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement at open-source@einride.tech.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+open-source@einride.tech.
 
 All complaints will be reviewed and investigated promptly and fairly.
 
-All community leaders are obligated to respect the privacy and security of the reporter of any incident.
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
 
-Enforcement Guidelines
-----------------------
+## Enforcement Guidelines
 
-Community leaders will follow these Community Impact Guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
 
 ### 1. Correction
 
-**Community Impact**: Use of inappropriate language or other behavior deemed unprofessional or unwelcome in the community.
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
 
-**Consequence**: A private, written warning from community leaders, providing clarity around the nature of the violation and an explanation of why the behavior was inappropriate. A public apology may be requested.
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
 
 ### 2. Warning
 
-**Community Impact**: A violation through a single incident or series of actions.
+**Community Impact**: A violation through a single incident or series of
+actions.
 
-**Consequence**: A warning with consequences for continued behavior. No interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, for a specified period of time. This includes avoiding interactions in community spaces as well as external channels like social media. Violating these terms may lead to a temporary or permanent ban.
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
 
 ### 3. Temporary Ban
 
-**Community Impact**: A serious violation of community standards, including sustained inappropriate behavior.
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
 
-**Consequence**: A temporary ban from any sort of interaction or public communication with the community for a specified period of time. No public or private interaction with the people involved, including unsolicited interaction with those enforcing the Code of Conduct, is allowed during this period. Violating these terms may lead to a permanent ban.
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
 
 ### 4. Permanent Ban
 
-**Community Impact**: Demonstrating a pattern of violation of community standards, including sustained inappropriate behavior, harassment of an individual, or aggression toward or disparagement of classes of individuals.
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
 
-**Consequence**: A permanent ban from any sort of public interaction within the community.
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
 
-Attribution
------------
+## Attribution
 
-This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.0, available at https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version 2.0,
+available at
+https://www.contributor-covenant.org/version/2/0/code_of_conduct.html.
 
-Community Impact Guidelines were inspired by [Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder](https://github.com/mozilla/diversity).
 
-For answers to common questions about this code of conduct, see the FAQ at https://www.contributor-covenant.org/faq. Translations are available at https://www.contributor-covenant.org/translations.
+For answers to common questions about this code of conduct, see the FAQ at
+https://www.contributor-covenant.org/faq. Translations are available at
+https://www.contributor-covenant.org/translations.

--- a/README.md
+++ b/README.md
@@ -1,18 +1,16 @@
-:herb: Sage
-===========
+# :herb: Sage
 
-Sage is a Make-like build tool inspired by [Mage](https://magefile.org/) that provides a curated and maintained set of build [tools](./tools) for Go projects.
+Sage is a Make-like build tool inspired by [Mage](https://magefile.org/) that
+provides a curated and maintained set of build [tools](./tools) for Go projects.
 
 [![Release](https://github.com/einride/sage/actions/workflows/release.yml/badge.svg)](https://github.com/einride/sage/actions/workflows/release.yml)
 
-Requirements
-------------
+## Requirements
 
--	[Go](https://golang.org/doc/install) >= 1.17
--	[GNU Make](https://www.gnu.org/software/make/)
+- [Go](https://golang.org/doc/install) >= 1.17
+- [GNU Make](https://www.gnu.org/software/make/)
 
-Getting started
----------------
+## Getting started
 
 To initilize Sage in a repository, just run:
 
@@ -22,12 +20,16 @@ go run go.einride.tech/sage@latest init
 
 Run `make`.
 
-Two changes should now have happened. If the project had a previous `Makefile` it should have been renamed to `Makefile.old` and a new should have been created. If the project have a dependabot config, a sage config should have been added.
+Two changes should now have happened. If the project had a previous `Makefile`
+it should have been renamed to `Makefile.old` and a new should have been
+created. If the project have a dependabot config, a sage config should have been
+added.
 
-Usage
------
+## Usage
 
-Sage imports, and targets within the Sagefiles, can be written to Makefiles, you can generate as many Makefiles as you want, see more at [Makefiles / Sage namespaces](https://github.com/einride/sage#makefiles--sage-namespaces).
+Sage imports, and targets within the Sagefiles, can be written to Makefiles, you
+can generate as many Makefiles as you want, see more at
+[Makefiles / Sage namespaces](https://github.com/einride/sage#makefiles--sage-namespaces).
 
 ### Sagefiles
 
@@ -35,7 +37,9 @@ You can have as many Sagefiles as you want in the `.sage` folder.
 
 #### Targets
 
-Any public function in the main package will be exported. Functions can have no return value but error. The following arguments are supported: Optional first argument of context.Context, string, int or bool.
+Any public function in the main package will be exported. Functions can have no
+return value but error. The following arguments are supported: Optional first
+argument of context.Context, string, int or bool.
 
 ```golang
 func All() {
@@ -57,7 +61,8 @@ func ConvcoCheck(ctx context.Context, rev string) error {
 
 #### Makefiles / Sage namespaces
 
-To generate Makefiles, a `main` method needs to exist in one of the Sagefiles where we call the `sg.GenerateMakefiles` method.
+To generate Makefiles, a `main` method needs to exist in one of the Sagefiles
+where we call the `sg.GenerateMakefiles` method.
 
 ```golang
 func main() {
@@ -70,7 +75,10 @@ func main() {
 }
 ```
 
-If another makefile is desired, lets say one that only includes Terraform targets, we utilize the `sg.Namespace` type and just add another `Makefile` to the `GenerateMakefiles` method and specify the namespace, path and default target.
+If another makefile is desired, lets say one that only includes Terraform
+targets, we utilize the `sg.Namespace` type and just add another `Makefile` to
+the `GenerateMakefiles` method and specify the namespace, path and default
+target.
 
 ```golang
 
@@ -97,7 +105,9 @@ func (Terraform) TerraformInitDev() {
 }
 ```
 
-It is also possible to embed a Namespace in order to add metadata to it and potentially reuse it for different Makefiles, the supported fields for an embedded Namespace are exported String, Int & Boolean.
+It is also possible to embed a Namespace in order to add metadata to it and
+potentially reuse it for different Makefiles, the supported fields for an
+embedded Namespace are exported String, Int & Boolean.
 
 ```golang
 
@@ -129,7 +139,8 @@ func (n MyNamespace) PrintName(ctx context.Context) error {
 }
 ```
 
-NOTE: The `sg.GenerateMakefiles` function is evaluated when the sage binary is built so doing something like this
+NOTE: The `sg.GenerateMakefiles` function is evaluated when the sage binary is
+built so doing something like this
 
 ```golang
 sg.Makefile{
@@ -138,11 +149,14 @@ sg.Makefile{
 },
 ```
 
-will cause whatever value the environment variable `Name` has at the time to be hardcoded in the built sage binary.
+will cause whatever value the environment variable `Name` has at the time to be
+hardcoded in the built sage binary.
 
 #### Dependencies
 
-Dependencies can be defined just by specificing the function, or with `sg.Fn` if the function takes arguments. `Deps` runs in parallel while `SerialDeps` runs serially.
+Dependencies can be defined just by specificing the function, or with `sg.Fn` if
+the function takes arguments. `Deps` runs in parallel while `SerialDeps` runs
+serially.
 
 ```golang
 sg.Deps(

--- a/example/.sage/main.go
+++ b/example/.sage/main.go
@@ -10,7 +10,7 @@ import (
 	"go.einride.tech/sage/tools/sggolangcilint"
 	"go.einride.tech/sage/tools/sggolicenses"
 	"go.einride.tech/sage/tools/sggoreview"
-	"go.einride.tech/sage/tools/sgmarkdownfmt"
+	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
 )
 
@@ -59,7 +59,7 @@ func GoLicenses(ctx context.Context) error {
 
 func FormatMarkdown(ctx context.Context) error {
 	sg.Logger(ctx).Println("formatting Markdown files...")
-	return sgmarkdownfmt.Command(ctx, "-w", ".").Run()
+	return sgmdformat.Command(ctx).Run()
 }
 
 func FormatYaml(ctx context.Context) error {

--- a/tools/sgmarkdownfmt/tools.go
+++ b/tools/sgmarkdownfmt/tools.go
@@ -1,3 +1,6 @@
+// Deprecated: markdownfmt is deprecated and has been replaced by mdformat.
+//
+// See sgmdformat package for a replacement.
 package sgmarkdownfmt
 
 import (

--- a/tools/sgmdformat/tools.go
+++ b/tools/sgmdformat/tools.go
@@ -19,8 +19,21 @@ const (
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {
 	sg.Deps(ctx, PrepareCommand)
-	args = append([]string{"."}, args...)
+	args = setDefaultArgs(args)
 	return sg.Command(ctx, sg.FromBinDir(name), args...)
+}
+
+// setDefaultArgs to iterate numbers on ordered lists and wrap at 80 chars.
+func setDefaultArgs(args []string) []string {
+	defaultArgs := []string{
+		"--number",
+		"--wrap",
+		"80",
+	}
+	if len(args) == 0 {
+		args = append(args, defaultArgs...)
+	}
+	return append([]string{"."}, args...)
 }
 
 func PrepareCommand(ctx context.Context) error {
@@ -45,6 +58,5 @@ func PrepareCommand(ctx context.Context) error {
 	if _, err := sgtool.CreateSymlink(mdformat); err != nil {
 		return err
 	}
-
 	return nil
 }


### PR DESCRIPTION
This changes the default markdown formatter from `markdownfmt` to `mdformat`. The reason to do this is for numerous reasons, the main ones are:
- Better support for GH flavour of markdown, which most users are used to and there are less surprises when formatted and rendered
- Supports reference style links, see issue: https://github.com/shurcooL/markdownfmt/issues/34
- Has support for line wrapping to make md files easier to read in raw format in terminal.

I have also added default arguments to mdformat to make it easier to adopt without having to specify these args yourself but can overwrite them as needed.