### PR TITLE
chore(deps): update golangci-lint to v1.55.2

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.54.2"
+	version = "1.55.2"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Release notes:

- v1.55.2: https://github.com/golangci/golangci-lint/releases/tag/v1.55.2
- v1.55.1: https://github.com/golangci/golangci-lint/releases/tag/v1.55.1
- v1.50.0: https://github.com/golangci/golangci-lint/releases/tag/v1.55.0
