### PR TITLE
mdformat: setup dependency file and add admonitions support

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,3 +20,8 @@ updates:
     directory: .sage
     schedule:
       interval: weekly
+
+  - package-ecosystem: pip
+    directory: tools/sgmdformat
+    schedule:
+      interval: weekly

--- a/tools/sgmdformat/requirements.txt
+++ b/tools/sgmdformat/requirements.txt
@@ -1,0 +1,1 @@
+mdformat-gfm==0.3.5

--- a/tools/sgmdformat/requirements.txt
+++ b/tools/sgmdformat/requirements.txt
@@ -1,1 +1,2 @@
 mdformat-gfm==0.3.5
+mdformat-admon==1.0.1

--- a/tools/sgpython/command.go
+++ b/tools/sgpython/command.go
@@ -37,6 +37,9 @@ func PrepareCommand(ctx context.Context) error {
 		// Special case: Avoid building from source if we already have Python 3 on the system.
 		sg.Logger(ctx).Printf("using system Python: %s", systemPython3)
 		symlink := filepath.Join(sg.FromBinDir(), name)
+		if err := os.MkdirAll(sg.FromBinDir(), 0o755); err != nil {
+			return err
+		}
 		if _, err := os.Lstat(symlink); err == nil {
 			if err := os.Remove(symlink); err != nil {
 				return err


### PR DESCRIPTION
This tracks Python dependencies in a `requirements.txt` file to easier handle multiple dependencies (likely only mdformat plugins).

Also, add the [admonitions mdformat plugin](https://github.com/KyleKing/mdformat-admon) to support [TechDocs admonitions](https://squidfunk.github.io/mkdocs-material/reference/admonitions/#admonitions).