### PR TITLE
feat(sgtrivy): add proper support for scanning only Terraform files

### DIFF
--- a/tools/sgtrivy/tools.go
+++ b/tools/sgtrivy/tools.go
@@ -18,7 +18,7 @@ import (
 var defaultConfig []byte
 
 const (
-	version = "0.46.0"
+	version = "0.48.0"
 	name    = "trivy"
 )
 
@@ -33,10 +33,10 @@ func defaultConfigPath() string {
 func CheckTerraformCommand(ctx context.Context, dir string) *exec.Cmd {
 	args := []string{
 		"config",
+		"--misconfig-scanners",
+		"terraform,terraformplan",
 		"--exit-code",
 		"1",
-		"--skip-files",
-		"./**/*.yaml",
 		dir,
 	}
 


### PR DESCRIPTION
Trivy has added support for specifying configuration scanners so we
bump trivy to the latest version and specify the terraform scanner
in the CheckTerraformCommand
