### PR TITLE
feat(mdformat): add mdformat-mkdocs

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,20 +21,20 @@ community include:
 - Being respectful of differing opinions, viewpoints, and experiences
 - Giving and gracefully accepting constructive feedback
 - Accepting responsibility and apologizing to those affected by our mistakes,
-  and learning from the experience
+    and learning from the experience
 - Focusing on what is best not just for us as individuals, but for the overall
-  community
+    community
 
 Examples of unacceptable behavior include:
 
 - The use of sexualized language or imagery, and sexual attention or advances of
-  any kind
+    any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
 - Publishing others' private information, such as a physical or email address,
-  without their explicit permission
+    without their explicit permission
 - Other conduct which could reasonably be considered inappropriate in a
-  professional setting
+    professional setting
 
 ## Enforcement Responsibilities
 

--- a/tools/sgmdformat/requirements.txt
+++ b/tools/sgmdformat/requirements.txt
@@ -1,2 +1,3 @@
 mdformat-gfm==0.3.6
+mdformat-mkdocs==2.0.2
 mdformat-admon==2.0.1


### PR DESCRIPTION
### Why?

- With the update of [mdformat-admon](https://github.com/einride/sage/pull/503) ([v2.0.0](https://github.com/KyleKing/mdformat-admon/releases/tag/v2.0.0)), the support for mkdocs admonitions was moved into https://github.com/KyleKing/mdformat-mkdocs.

### What?

- Added dependency https://github.com/KyleKing/mdformat-mkdocs.
- Ran `make format-markdown` (added some changes to the code of conduct).

### Notes

- Slack ref: https://einride.slack.com/archives/C02UQKNJBJL/p1707141026793539
- This was not actually tested on mkdocs admonitions... so, let's just 🤞 
- [GitHub flavoured admonitions](https://github.com/orgs/community/discussions/16925) still don't work as the formatter will break them by injecting escaping backslashes before the brackets.
- @thall noticed that [the mdformat readme](https://github.com/executablebooks/mdformat#installing) mentions that "for full github support", we should add `mdformat-frontmatter` and `mdformat-footnote` too, but this still doesn't enable GitHub flavoured admonitions.