### PR TITLE
Revert "feat(mdformat): add mdformat-mkdocs"

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -21,20 +21,20 @@ community include:
 - Being respectful of differing opinions, viewpoints, and experiences
 - Giving and gracefully accepting constructive feedback
 - Accepting responsibility and apologizing to those affected by our mistakes,
-    and learning from the experience
+  and learning from the experience
 - Focusing on what is best not just for us as individuals, but for the overall
-    community
+  community
 
 Examples of unacceptable behavior include:
 
 - The use of sexualized language or imagery, and sexual attention or advances of
-    any kind
+  any kind
 - Trolling, insulting or derogatory comments, and personal or political attacks
 - Public or private harassment
 - Publishing others' private information, such as a physical or email address,
-    without their explicit permission
+  without their explicit permission
 - Other conduct which could reasonably be considered inappropriate in a
-    professional setting
+  professional setting
 
 ## Enforcement Responsibilities
 

--- a/tools/sgmdformat/requirements.txt
+++ b/tools/sgmdformat/requirements.txt
@@ -1,3 +1,2 @@
 mdformat-gfm==0.3.6
-mdformat-mkdocs==2.0.2
 mdformat-admon==2.0.1


### PR DESCRIPTION
Reverts einride/sage#506

This caused all sorts of havoc. Now `make format-markdown` complains about images that uses space in its caption, like `[foo bar](image.png)` and also it complains about links that are longer than 80 characters.

And all this without even mentioning what's wrong. Example:

```
❯ make format-markdown
[sage] building binary and generating Makefiles...
[format-markdown] formatting Markdown files...
[format-markdown] Error: Could not format
[format-markdown] "/Users/fredrik/code/work/private/book-service/docs/runbooks/managing-cloudsql-maintenance.md".
[format-markdown] 
[format-markdown] The formatted Markdown renders to different HTML than the input Markdown. This
[format-markdown] is likely a bug in mdformat. Please create an issue report here, including the
[format-markdown] input Markdown: https://github.com/executablebooks/mdformat/issues
[format-markdown] exit status 1
make: *** [format-markdown] Error 1
```
