### PR TITLE
version bumps feb 2024

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.59.1"
+	version = "1.63.6"
 	name    = "api-linter"
 )
 

--- a/tools/sgbuf/tools.go
+++ b/tools/sgbuf/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "1.27.1"
+	version = "1.29.0"
 	name    = "buf"
 )
 

--- a/tools/sggh/tools.go
+++ b/tools/sggh/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "gh"
-	version = "2.37.0"
+	version = "2.44.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.56.1"
+	version = "1.56.2"
 )
 
 //go:embed golangci.yml

--- a/tools/sggolangmigrate/tools.go
+++ b/tools/sggolangmigrate/tools.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "4.16.2"
+	version = "4.17.0"
 	name    = "migrate"
 )
 

--- a/tools/sggoreleaser/tools.go
+++ b/tools/sggoreleaser/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "goreleaser"
-	version = "1.21.2"
+	version = "1.24.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggosemanticrelease/tools.go
+++ b/tools/sggosemanticrelease/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "go-semantic-release"
-	version = "2.28.0"
+	version = "2.30.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggovulncheck/tools.go
+++ b/tools/sggovulncheck/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "govulncheck"
-	version = "v1.0.1"
+	version = "v1.0.4"
 )
 
 // Command returns an [*exec.Cmd] for govulncheck.

--- a/tools/sgko/tools.go
+++ b/tools/sgko/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "ko"
-	version = "0.15.0"
+	version = "0.15.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -20,7 +20,7 @@ import (
 const tripleQuote = "```" // required by goconst since used more than 3
 
 const (
-	version    = "1.7.1"
+	version    = "1.7.3"
 	binaryName = "terraform"
 )
 

--- a/tools/sgyamlfmt/tools.go
+++ b/tools/sgyamlfmt/tools.go
@@ -19,7 +19,7 @@ var defaultConfig []byte
 
 const (
 	name              = "yamlfmt"
-	version           = "0.10.0"
+	version           = "0.11.0"
 	defaultConfigName = ".yamlfmt"
 )
 


### PR DESCRIPTION
- feat(api-linter): bump to v1.63.6
- feat(buf): bump to v1.29.0
- feat(gh): bump to v2.44.1
- feat(golangci-lint): bump to v1.56.2
- feat(golang-migrate): bump to v4.17.0
- feat(goreleaser): bump to v1.24.0
- feat(go-semantic-release): bump to v2.30.0
- feat(govulncheck): bump to v1.0.4
- feat(ko): bump to v0.15.1
- feat(terraform): bump to v1.7.3
- feat(yamlfmt): bump to v0.11.0
