### PR TITLE
fix(sg): remove -fm suffix in target names

### DIFF
--- a/sg/fn_test.go
+++ b/sg/fn_test.go
@@ -1,0 +1,55 @@
+package sg
+
+import (
+	"context"
+	"testing"
+)
+
+func TestFn_Name(t *testing.T) {
+	ns := namespace{}
+	for _, tt := range []struct {
+		name     string
+		fn       interface{}
+		expected string
+	}{
+		{
+			name:     "func",
+			fn:       MyFunc,
+			expected: "go.einride.tech/sage/sg.MyFunc",
+		},
+		{
+			name:     "anonymous",
+			fn:       func(_ context.Context) error { return nil },
+			expected: "go.einride.tech/sage/sg.TestFn_Name.func1",
+		},
+		{
+			name:     "namespace",
+			fn:       namespace.MyFunc,
+			expected: "go.einride.tech/sage/sg.namespace.MyFunc",
+		},
+		{
+			name:     "namespace value",
+			fn:       ns.MyFunc,
+			expected: "go.einride.tech/sage/sg.namespace.MyFunc-fm",
+		},
+	} {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			fn := Fn(tt.fn)
+			got := fn.Name()
+			if got != tt.expected {
+				t.Fatalf("expected %q to be %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func MyFunc(_ context.Context) error {
+	return nil
+}
+
+type namespace Namespace
+
+func (namespace) MyFunc(_ context.Context) error {
+	return nil
+}

--- a/sg/fn_test.go
+++ b/sg/fn_test.go
@@ -30,7 +30,7 @@ func TestFn_Name(t *testing.T) {
 		{
 			name:     "namespace value",
 			fn:       ns.MyFunc,
-			expected: "go.einride.tech/sage/sg.namespace.MyFunc-fm",
+			expected: "go.einride.tech/sage/sg.namespace.MyFunc",
 		},
 	} {
 		tt := tt


### PR DESCRIPTION
It seems common to pass arguments to Deps and SerialDeps as below:
```go
type namespace sg.Namespace

func (n namespace) Default(ctx context.Context) error {
            sg.Deps(ctx, n.FirstTarget, n.SecondTarget)
                    return nil
}

```

Currently this leads to logs in the dep targets to be prefixed with
`[namespace:first-target-fm]` and `[namespace:second-target-fm]`, because
of how the compiler implements methods bound to specific receivers. If
instead the dependencies were specified as:
```go
sg.Deps(ctx, namespace.FirstTarget, namespace.SecondTarget)
```
the names would log prefixes would simply be `[namespace:first-target]`
and `[namespace:second-target]`.

This commit removes the `-fm` suffix. This is safe as no function name
in go can include a hyphen.
