### PR TITLE
Remove goconst, add protogetter

### DIFF
--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -118,6 +118,10 @@ linters:
     # [fast: true, auto-fix: false]
     - promlinter
 
+    # Reports direct reads from proto message fields when getters should be used.
+    # [fast: false, auto-fix: true]
+    - protogetter
+
     # Check whether Err of rows is checked successfully.
     # [fast: false, auto-fix: false]
     - rowserrcheck
@@ -242,6 +246,9 @@ linters-settings:
     simple: true
     range-loops: true
     for-loops: true
+
+  protogetter:
+    skip-any-generated: true
 
   staticcheck:
     go: 1.17

--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -46,10 +46,6 @@ linters:
     # [fast: true, auto-fix: false]
     - gochecknoinits
 
-    # Find repeated strings that could be replaced by a constant.
-    # [fast: true, auto-fix: false]
-    - goconst
-
     # Check for bugs, performance and style issues.
     # [fast: false, auto-fix: false]
     - gocritic
@@ -262,10 +258,6 @@ linters-settings:
     # Don't enforce %w to minimize implicit interface leakage.
     # https://github.com/dwmkerr/hacker-laws#hyrums-law-the-law-of-implicit-interfaces
     errorf: false
-
-  goconst:
-    ignore-tests: true
-    min-occurrences: 5
 
   gomoddirectives:
     replace-local: true


### PR DESCRIPTION
This removes goconst following internal discussions. But also adds protogetter: https://github.com/ghostiam/protogetter
