### PR TITLE
feat(golangci-lint): add Fix helper

### DIFF
--- a/tools/sggolangcilint/golangci.fix.yml
+++ b/tools/sggolangcilint/golangci.fix.yml
@@ -1,0 +1,48 @@
+run:
+  timeout: 10m
+  allow-serial-runners: true
+  skip-dirs:
+    - node_modules
+
+issues:
+  fix: true
+
+linters:
+  disable-all: true
+  enable:
+    # Check package import order and make it always deterministic.
+    # [fast: true, auto-fix: true]
+    - gci
+
+    # Check if comments end in a period.
+    # [fast: true, auto-fix: true]
+    - godot
+
+    # Check whether code was gofumpt-ed.
+    # [fast: true, auto-fix: true]
+    - gofumpt
+
+    # Find commonly misspelled English words in comments.
+    # [fast: true, auto-fix: true]
+    - misspell
+
+    # Reports direct reads from proto message fields when getters should be used.
+    # [fast: false, auto-fix: true]
+    - protogetter
+
+    # Detect leading and trailing whitespace.
+    # [fast: true, auto-fix: true]
+    - whitespace
+
+linters-settings:
+  gofumpt:
+    extra-rules: true
+
+  misspell:
+    locale: US
+    ignore-words:
+      - cancelled
+      - cancelling
+
+  protogetter:
+    skip-any-generated: true


### PR DESCRIPTION
Runs `golangci-lint --fix` with a default fix config which is a subset
of the default lint config, with a few modifications:

* Don't run in parallell (may cause issues between fixers)
* Remove all linters who are not fixers (to speed up invocation)
