### PR TITLE
feat: add go-format example target

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -10,6 +10,7 @@ import (
 	"go.einride.tech/sage/tools/sggo"
 	"go.einride.tech/sage/tools/sggolangcilint"
 	"go.einride.tech/sage/tools/sggolicenses"
+	"go.einride.tech/sage/tools/sggolines"
 	"go.einride.tech/sage/tools/sggoreview"
 	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
@@ -49,6 +50,16 @@ func GoReview(ctx context.Context) error {
 func GoLint(ctx context.Context) error {
 	sg.Logger(ctx).Println("linting Go files...")
 	return sggolangcilint.Run(ctx)
+}
+
+func GoLintFix(ctx context.Context) error {
+	sg.Logger(ctx).Println("fixing Go files...")
+	return sggolangcilint.Fix(ctx)
+}
+
+func GoFormat(ctx context.Context) error {
+	sg.Logger(ctx).Println("formatting Go files...")
+	return sggolines.Run(ctx)
 }
 
 func GoLicenses(ctx context.Context) error {

--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,10 @@ format-yaml: $(sagefile)
 git-verify-no-diff: $(sagefile)
 	@$(sagefile) GitVerifyNoDiff
 
+.PHONY: go-format
+go-format: $(sagefile)
+	@$(sagefile) GoFormat
+
 .PHONY: go-licenses
 go-licenses: $(sagefile)
 	@$(sagefile) GoLicenses
@@ -74,6 +78,10 @@ go-licenses: $(sagefile)
 .PHONY: go-lint
 go-lint: $(sagefile)
 	@$(sagefile) GoLint
+
+.PHONY: go-lint-fix
+go-lint-fix: $(sagefile)
+	@$(sagefile) GoLintFix
 
 .PHONY: go-mod-tidy
 go-mod-tidy: $(sagefile)

--- a/example/.sage/main.go
+++ b/example/.sage/main.go
@@ -10,6 +10,7 @@ import (
 	"go.einride.tech/sage/tools/sggo"
 	"go.einride.tech/sage/tools/sggolangcilint"
 	"go.einride.tech/sage/tools/sggolicenses"
+	"go.einride.tech/sage/tools/sggolines"
 	"go.einride.tech/sage/tools/sggoreview"
 	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
@@ -52,6 +53,16 @@ func GoReview(ctx context.Context) error {
 func GoLint(ctx context.Context) error {
 	sg.Logger(ctx).Println("linting Go files...")
 	return sggolangcilint.Run(ctx)
+}
+
+func GoLintFix(ctx context.Context) error {
+	sg.Logger(ctx).Println("fixing Go files...")
+	return sggolangcilint.Fix(ctx)
+}
+
+func GoFormat(ctx context.Context) error {
+	sg.Logger(ctx).Println("formatting Go files...")
+	return sggolines.Run(ctx)
 }
 
 func GoLicenses(ctx context.Context) error {

--- a/tools/sggofumpt/tools.go
+++ b/tools/sggofumpt/tools.go
@@ -1,4 +1,4 @@
-package sggolines
+package sggofumpt
 
 import (
 	"context"
@@ -10,27 +10,12 @@ import (
 
 	"go.einride.tech/sage/sg"
 	"go.einride.tech/sage/sgtool"
-	"go.einride.tech/sage/tools/sggofumpt"
 )
 
 const (
-	name    = "golines"
-	version = "0.12.2"
+	name    = "gofumpt"
+	version = "0.6.0"
 )
-
-// Run golines on all Go files in the current git root with gofumpt as default formatter.
-func Run(ctx context.Context) error {
-	sg.Deps(ctx, sggofumpt.PrepareCommand)
-	return Command(
-		ctx,
-		"--base-formatter=gofumpt",
-		"--ignore-generated",
-		"--max-len=120",
-		"--tab-len=1",
-		"--write-output",
-		".",
-	).Run()
-}
 
 // Command returns an [*exec.Cmd] for golines.
 func Command(ctx context.Context, args ...string) *exec.Cmd {
@@ -43,12 +28,9 @@ func PrepareCommand(ctx context.Context) error {
 	binary := filepath.Join(binDir, name)
 	hostOS := runtime.GOOS
 	hostArch := runtime.GOARCH
-	if hostOS == sgtool.Darwin {
-		hostArch = "all"
-	}
 	binURL := fmt.Sprintf(
-		"https://github.com/segmentio/golines/"+
-			"releases/download/v%s/golines_%s_%s_%s.tar.gz",
+		"https://github.com/mvdan/gofumpt/"+
+			"releases/download/v%s/gofumpt_v%s_%s_%s",
 		version,
 		version,
 		hostOS,
@@ -58,8 +40,7 @@ func PrepareCommand(ctx context.Context) error {
 		ctx,
 		binURL,
 		sgtool.WithDestinationDir(binDir),
-		sgtool.WithUntarGz(),
-		sgtool.WithRenameFile(fmt.Sprintf("golines_%s_%s_%s/golines", version, hostOS, hostArch), name),
+		sgtool.WithRenameFile(fmt.Sprintf("gofumpt_v%s_%s_%s", version, hostOS, hostArch), name),
 		sgtool.WithSkipIfFileExists(binary),
 		sgtool.WithSymlink(binary),
 	); err != nil {


### PR DESCRIPTION
Runs `golangci-lint --fix` and `golines`.
