### PR TITLE
chore(golangci-lint): align with updated config options

### DIFF
--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -1,10 +1,10 @@
 run:
   timeout: 10m
-  skip-dirs:
-    - node_modules
 
 issues:
   fix: false
+  exclude-dirs:
+    - node_modules
 
 linters:
   disable-all: true


### PR DESCRIPTION
In `golangci-lint` [v1.57.0](https://github.com/golangci/golangci-lint/releases/tag/v1.57.0) `run.skip-dirs` is replaced by `issues.exclude-dirs`.