### PR TITLE
bump versions april 2024

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @einride/platform-engineering @thall @Edholm
+* @einride/platform-engineering

--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.63.6"
+	version = "1.64.0"
 	name    = "api-linter"
 )
 

--- a/tools/sgbuf/tools.go
+++ b/tools/sgbuf/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "1.29.0"
+	version = "1.30.1"
 	name    = "buf"
 )
 

--- a/tools/sggh/tools.go
+++ b/tools/sggh/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "gh"
-	version = "2.44.1"
+	version = "2.47.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -225,11 +225,7 @@ linters-settings:
             reason: "More reliably supports protobuf messages."
 
   gofumpt:
-    lang-version: 1.17
     extra-rules: true
-
-  gosimple:
-    go: 1.17
 
   lll:
     line-length: 120
@@ -250,15 +246,10 @@ linters-settings:
     skip-any-generated: true
 
   staticcheck:
-    go: 1.17
     checks: [all]
 
   stylecheck:
-    go: 1.17
     checks: [all]
-
-  unused:
-    go: 1.17
 
   errorlint:
     # Don't enforce %w to minimize implicit interface leakage.

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.57.0"
+	version = "1.57.2"
 )
 
 //go:embed golangci.yml

--- a/tools/sggoreleaser/tools.go
+++ b/tools/sggoreleaser/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "goreleaser"
-	version = "1.24.0"
+	version = "1.25.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgko/tools.go
+++ b/tools/sgko/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "ko"
-	version = "0.15.1"
+	version = "0.15.2"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgmarkdownfmt/tools.go
+++ b/tools/sgmarkdownfmt/tools.go
@@ -16,11 +16,17 @@ const version = "75134924a9fd3335f76a9709314c5f5cef4d6ddc"
 //nolint:gochecknoglobals
 var commandPath string
 
+// Command returns an [exec.Cmd] pointing to the markdownfmt binary.
+//
+// Deprecated: Use sgmdformat.Command instead.
 func Command(ctx context.Context, args ...string) *exec.Cmd {
 	sg.Deps(ctx, PrepareCommand)
 	return sg.Command(ctx, commandPath, args...)
 }
 
+// PrepareCommand downloads the markdownfmt binary and adds it to the PATH.
+//
+// Deprecated: Use sgmdformat.PrepareCommand instead.
 func PrepareCommand(ctx context.Context) error {
 	binary, err := sgtool.GoInstall(ctx, "github.com/shurcooL/markdownfmt", version)
 	if err != nil {

--- a/tools/sgprotocgengogrpc/tools.go
+++ b/tools/sgprotocgengogrpc/tools.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	version = "1.2.0"
+	version = "1.3.0"
 	name    = "protoc-gen-go-grpc"
 )
 

--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -20,7 +20,7 @@ import (
 const tripleQuote = "```" // required by goconst since used more than 3
 
 const (
-	version    = "1.7.3"
+	version    = "1.7.5"
 	binaryName = "terraform"
 )
 

--- a/tools/sgtrivy/tools.go
+++ b/tools/sgtrivy/tools.go
@@ -18,7 +18,7 @@ import (
 var defaultConfig []byte
 
 const (
-	version = "0.48.0"
+	version = "0.50.1"
 	name    = "trivy"
 )
 


### PR DESCRIPTION
- feat(api-linter): bump to v1.64.0
- feat(buf): bump to v1.30.1
- feat(gh): bump to v2.47.0
- feat(golangci-lint): bump to v1.57.2
- feat(goreleaser): bump to v1.25.1
- feat(ko): bump to v0.15.2
- feat(markdownfmt): mark as deprecated
- feat(protoc-gen-go-grpc): bump to v1.3.0
- feat(terraform): bump to v1.7.5
- feat(trivy): bump to v0.50.1
- chore: remove individuals from CODEOWNERS
