### PR TITLE
fix(sgtrivy): update misconfig-scanners

### DIFF
--- a/tools/sgtrivy/tools.go
+++ b/tools/sgtrivy/tools.go
@@ -34,7 +34,7 @@ func CheckTerraformCommand(ctx context.Context, dir string) *exec.Cmd {
 	args := []string{
 		"config",
 		"--misconfig-scanners",
-		"terraform,terraformplan",
+		"terraform,terraformplan-json,terraformplan-snapshot",
 		"--exit-code",
 		"1",
 		dir,


### PR DESCRIPTION
Trivy has added support for scanning terraform plan snapshots and
thus so updated the config names.

See [PR](https://github.com/aquasecurity/trivy/pull/6176)

Fixes error:
```
[terraform:security-check] 2024-04-09T09:37:47.378Z	INFO	Misconfiguration scanning is enabled
[terraform:security-check] 2024-04-09T09:37:47.378Z	INFO	Need to update the built-in policies
[terraform:security-check] 2024-04-09T09:37:47.378Z	INFO	Downloading the built-in policies...
[terraform:security-check] 46.13 KiB / 46.13 KiB [-----------------------------------------------------------] 100.00% ? p/s 0s
[terraform:security-check] 2024-04-09T09:37:47.570Z	ERROR	Invalid misconfig scanners specified: [terraform terraformplan] defaulting to use all misconfig scanners
[terraform:security-check] 2024-04-09T09:37:50.125Z	INFO	Detected config files: 4
```

```
$ ../.sage/bin/trivy config --help
...
Misconfiguration Flags
      --misconfig-scanners strings        comma-separated list of misconfig scanners to use for misconfiguration scanning (default [azure-arm,cloudformation,dockerfile,helm,kubernetes,terraform,terraformplan-json,terraformplan-snapshot])
...
```