### PR TITLE
Ignore Go toolchain for improved caching

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -41,6 +41,13 @@ runs:
         # Needed for conventional commit linting.
         fetch-depth: ${{ inputs.fetch-depth }}
 
+    - name: Configure env for toolchain ignore
+      # See issues:
+      #  - https://github.com/actions/setup-go/issues/424
+      #  - https://github.com/actions/setup-go/pull/460
+      shell: bash
+      run: echo "GOTOOLCHAIN=local" >> "$GITHUB_ENV"
+
     - name: Set up Go
       uses: actions/setup-go@v5
       with:


### PR DESCRIPTION
## Why?

When the version of Go in the go directive of go.mod is different from the
version in the toolchain directive there is a cache conflict which causes errors
on cache extraction.

## What?

Force go to always use the local toolchain (i.e. the one the one that shipped
with the go command being run) via setting the GOTOOLCHAIN environment variable
to `local`.

This means we'll have to make sure our GHA workflows uses the intended Go
version.
