### PR TITLE
unexpected memoization of sage targets

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -24,6 +24,13 @@ func main() {
 	)
 }
 
+func DoubleGitVerifyNoDiff(ctx context.Context) error {
+	sg.SerialDeps(ctx, GitVerifyNoDiff)
+	sg.SerialDeps(ctx, FormatMarkdown)
+	sg.SerialDeps(ctx, GitVerifyNoDiff) // this should report a change
+	return nil
+}
+
 func Default(ctx context.Context) error {
 	sg.Deps(ctx, ConvcoCheck, GoLint, GoTest, FormatMarkdown, FormatYaml, BackstageValidate)
 	sg.SerialDeps(ctx, GoModTidy)

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -32,10 +32,9 @@ func DoubleGitVerifyNoDiff(ctx context.Context) error {
 }
 
 func Default(ctx context.Context) error {
-	sg.Deps(ctx, ConvcoCheck, GoLint, GoTest, FormatMarkdown, FormatYaml, BackstageValidate)
-	sg.SerialDeps(ctx, GoModTidy)
-	sg.SerialDeps(ctx, GoLicenses, GitVerifyNoDiff)
-	return nil
+	sg.Deps(ctx, DoubleGitVerifyNoDiff)
+	cmd := sggit.Command(ctx, "status", "--short")
+	return cmd.Run()
 }
 
 func GoModTidy(ctx context.Context) error {

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ convco-check: $(sagefile)
 default: $(sagefile)
 	@$(sagefile) Default
 
+.PHONY: double-git-verify-no-diff
+double-git-verify-no-diff: $(sagefile)
+	@$(sagefile) DoubleGitVerifyNoDiff
+
 .PHONY: format-markdown
 format-markdown: $(sagefile)
 	@$(sagefile) FormatMarkdown

--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ provides a curated and maintained set of build [tools](./tools) for Go projects.
 [![Release](https://github.com/einride/sage/actions/workflows/release.yml/badge.svg)](https://github.com/einride/sage/actions/workflows/release.yml)
 
 ## Requirements
-
 - [Go](https://golang.org/doc/install) >= 1.17
 - [GNU Make](https://www.gnu.org/software/make/)
 


### PR DESCRIPTION
Sage targets results are memoized, so if invoked multiple times, the result from the first execution is returned.

In this example PR, `GitVeryifyNoDiff` is called first, then `FormatMarkdown` and then `GitVeryifyNoDiff`, then second call wont report any changes since it gets a cached value back, to me this was unexpected.

The memoization happens [here](https://github.com/einride/sage/blob/master/sg/internal/runner/runner.go#L17)

The behavior is verified with a exaction of `git status --short`:
![image](https://github.com/einride/sage/assets/102452/4d4ab351-b59f-4114-8f31-5b335cf81225)
