### PR TITLE
summer bumping 2024

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.64.0"
+	version = "1.66.1"
 	name    = "api-linter"
 )
 

--- a/tools/sgbuf/tools.go
+++ b/tools/sgbuf/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "1.30.1"
+	version = "1.33.0"
 	name    = "buf"
 )
 

--- a/tools/sgconvco/tools.go
+++ b/tools/sgconvco/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "convco"
-	version = "0.4.3"
+	version = "0.5.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggh/tools.go
+++ b/tools/sggh/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "gh"
-	version = "2.47.0"
+	version = "2.51.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.57.2"
+	version = "1.59.1"
 )
 
 //go:embed golangci.yml

--- a/tools/sggolangmigrate/tools.go
+++ b/tools/sggolangmigrate/tools.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	version = "4.17.0"
+	version = "4.17.1"
 	name    = "migrate"
 )
 

--- a/tools/sggoreleaser/tools.go
+++ b/tools/sggoreleaser/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "goreleaser"
-	version = "1.25.1"
+	version = "2.0.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sggovulncheck/tools.go
+++ b/tools/sggovulncheck/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "govulncheck"
-	version = "v1.1.0"
+	version = "v1.1.2"
 )
 
 // Command returns an [*exec.Cmd] for govulncheck.

--- a/tools/sgko/tools.go
+++ b/tools/sgko/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "ko"
-	version = "0.15.2"
+	version = "0.15.4"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {

--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -20,7 +20,7 @@ import (
 const tripleQuote = "```" // required by goconst since used more than 3
 
 const (
-	version    = "1.7.5"
+	version    = "1.8.5"
 	binaryName = "terraform"
 )
 

--- a/tools/sgtrivy/tools.go
+++ b/tools/sgtrivy/tools.go
@@ -18,7 +18,7 @@ import (
 var defaultConfig []byte
 
 const (
-	version = "0.50.1"
+	version = "0.52.1"
 	name    = "trivy"
 )
 

--- a/tools/sgyamlfmt/tools.go
+++ b/tools/sgyamlfmt/tools.go
@@ -19,7 +19,7 @@ var defaultConfig []byte
 
 const (
 	name              = "yamlfmt"
-	version           = "0.11.0"
+	version           = "0.12.1"
 	defaultConfigName = ".yamlfmt"
 )
 


### PR DESCRIPTION
- feat(api-linter): bump to v1.66.1
- feat(buf): bump to v1.33.0
- feat(convco): bump to v0.5.1
- feat(gh): bump to v2.51.0
- feat(golangci-lint): bump to v1.59.1
- feat(golang-migrate): bump to v4.17.1
- feat(goreleaser): bump to v2.0.1
- feat(govulncheck): bump to v1.1.2
- feat(ko): bump to v0.15.4
- feat(terraform): bump to v1.8.5
- feat(trivy): bump to v0.52.1
- feat(yamlfmt): bump to v0.12.1
