### PR TITLE
fix: allow word analyses for misspell linter

### DIFF
--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -236,6 +236,7 @@ linters-settings:
     ignore-words:
       - cancelled
       - cancelling
+      - analyses # allow analyses as a plural form of analysis
 
   prealloc:
     simple: true


### PR DESCRIPTION
Allow word `analyses` as a plural form of analysis in linter.