### PR TITLE
feat(golangci-lint): bump to 1.60.1, support for go 1.23.0

### DIFF
--- a/sg/deps.go
+++ b/sg/deps.go
@@ -47,7 +47,7 @@ func Deps(ctx context.Context, functions ...interface{}) {
 		go func() {
 			defer func() {
 				if v := recover(); v != nil {
-					errs[i] = fmt.Errorf(fmt.Sprint(v))
+					errs[i] = fmt.Errorf("%s", v)
 				}
 				wg.Done()
 			}()

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.59.1"
+	version = "1.60.1"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Bump Golangci-lint to 1.60.1. 

First version with support for Go 1.23 - [Release Notes](https://github.com/golangci/golangci-lint/releases/tag/v1.60.1)