### PR TITLE
fix: address unreliable go dependency caching

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -53,7 +53,7 @@ runs:
           /home/runner/.cache/go-build
           /home/runner/go/pkg/mod
           /home/runner/go/bin
-        key: ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('./.sage/go.sum') }}
+        key: ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-
           ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -17,11 +17,6 @@ inputs:
     required: false
     default: '1.22'
 
-  cache-dependency-path:
-    description: Path to the go.sum file(s) to use in caching.
-    required: false
-    default: go.sum
-
   check-latest:
     description: If true, checks whether the cached go version is the latest, if not then downloads the latest. Useful when you need to use the latest version.
     required: false
@@ -46,16 +41,18 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
         check-latest: ${{ inputs.check-latest }}
-        cache: ${{ inputs.disableCache != 'true' }}
-        cache-dependency-path: ${{ inputs.cache-dependency-path }}
+        cache: false  # cache is handled by separate actions/cache step.
 
-    - name: Cache sage folders
+    - name: Set up cache
       if: ${{ inputs.disableCache != 'true' }}
       uses: actions/cache@v4
       with:
         path: |
           ./.sage/tools
           ./.sage/bin
+          /home/runner/.cache/go-build
+          /home/runner/go/pkg/mod
+          /home/runner/go/bin
         key: ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('./.sage/go.sum') }}
         restore-keys: |
           ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-


### PR DESCRIPTION
## Why this change?

This aims to solve the problem where two caches are uploaded (one by `actions/go-setup` and one by `actions/cache`, but where the one from `actions/go-setup` was created by the fastest workflow (with the least
dependencies) and then often used by the slower/heavier workflows. These heavier workflows reuse the cache but it does not contain all dependencies and so it has to re-download and re-build them on every commit. The cache is not rebuilt because there are additional dependencies downloaded.

TL;DR the wrong cache is being used.

The issue is described in detail here: https://github.com/actions/setup-go/issues/358

## What was changed?

- Stop using cache by `actions/go-setup`.
- Extend caching of `actions/cache` so to also cover Go dependencies and builds. Effectively doing what `actions/go-setup` was supposed to handle.
- Extend the cache key to use a hash based on _all_ `go.sum` files in the project, not just `.sage/go.sum`.
