### PR TITLE
fix: PR cache fallback to master/main branch's cache

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -43,6 +43,21 @@ runs:
         check-latest: ${{ inputs.check-latest }}
         cache: false  # cache is handled by separate actions/cache step, see https://github.com/actions/setup-go/issues/358
 
+    - name: Generate cache key
+      id: cache-key
+      shell: bash
+      run: |
+
+        echo "restore_key=${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}-default" >> $GITHUB_OUTPUT
+
+        if [[ "${{ github.ref_name }}" == "main" || "${{ github.ref_name }}" == "master" ]]; then
+          echo "cache_key=${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}-default" >> $GITHUB_OUTPUT
+        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
+          echo "cache_key=${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}-PR" >> $GITHUB_OUTPUT
+        else
+          echo "cache_key=${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
+        fi
+
     - name: Set up cache
       if: ${{ inputs.disableCache != 'true' }}
       uses: actions/cache@v4
@@ -53,10 +68,7 @@ runs:
           /home/runner/.cache/go-build
           /home/runner/go/pkg/mod
           /home/runner/go/bin
-        key: ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
+        key: ${{ steps.cache-key.outputs.cache_key }}
         restore-keys: |
-          ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-
-          ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-
-          ${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-
-          ${{ runner.os }}-sage-${{ github.workflow }}-
-          ${{ runner.os }}-sage-
+          ${{ steps.cache-key.outputs.restore_key }}
+

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -41,7 +41,7 @@ runs:
       with:
         go-version: ${{ inputs.go-version }}
         check-latest: ${{ inputs.check-latest }}
-        cache: false  # cache is handled by separate actions/cache step.
+        cache: false  # cache is handled by separate actions/cache step, see https://github.com/actions/setup-go/issues/358
 
     - name: Set up cache
       if: ${{ inputs.disableCache != 'true' }}

--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -43,21 +43,11 @@ runs:
         check-latest: ${{ inputs.check-latest }}
         cache: false  # cache is handled by separate actions/cache step, see https://github.com/actions/setup-go/issues/358
 
-    - name: Generate cache key
-      id: cache-key
-      shell: bash
-      run: |
-
-        echo "restore_key=${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}-default" >> $GITHUB_OUTPUT
-
-        if [[ "${{ github.ref_name }}" == "main" || "${{ github.ref_name }}" == "master" ]]; then
-          echo "cache_key=${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}-default" >> $GITHUB_OUTPUT
-        elif [[ "${{ github.event_name }}" == "pull_request" ]]; then
-          echo "cache_key=${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}-PR" >> $GITHUB_OUTPUT
-        else
-          echo "cache_key=${{ runner.os }}-sage-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}" >> $GITHUB_OUTPUT
-        fi
-
+    # NOTE: cache key and restore key is not the same;
+    # We want to always re-use the cache created by master in all our PRs. We also want any PR which modifies go.sum to create a new cache for itself.
+    # Therefore the cache key is set to use GITHUB_REF_NAME and the restore key is set to use GITHUB_BASE_REF.
+    # For more details, see https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#default-environment-variables
+    # NOTE: you need to build on push to master and on pull request in the repos which uses this reusable workflow.
     - name: Set up cache
       if: ${{ inputs.disableCache != 'true' }}
       uses: actions/cache@v4
@@ -68,7 +58,6 @@ runs:
           /home/runner/.cache/go-build
           /home/runner/go/pkg/mod
           /home/runner/go/bin
-        key: ${{ steps.cache-key.outputs.cache_key }}
+        key: ${{ runner.os }}-${{ github.ref_name }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
         restore-keys: |
-          ${{ steps.cache-key.outputs.restore_key }}
-
+          ${{ runner.os }}-${{ github.base_ref }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}


### PR DESCRIPTION
## Make sure a PR always gets a cache hit

(unless there is no cache yet, or course)

### Why this change?

In #571 we disabled `actions/go-setup`, and delegated all caching to `actions/cache` because we can reliably pass it a cache key.

However, it turns out that there are specific constraints/requirements around caches and branches:
https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/caching-dependencies-to-speed-up-workflows#restrictions-for-accessing-a-cache

Right now, the first commit of a PR doesn't use the cache that was created by another PR. But:

> Workflow runs can restore caches created in either the current branch or the default branch (usually main).

This means we could make sure to have a "master cache" that the PR falls back onto (using a `restore-keys` entry).


### What was changed?

#### First try (commit "[fix: cache from branch, fallback to target branch](https://github.com/einride/sage/pull/573/commits/a5ed9ae1a86e51e3c7b135e48ed13c9954775a75)")

- Added an if/elif/else dance, which generated the cache `key` and `restore-keys` values.

#### Second try (commit "[refactor: simplify cache keys](https://github.com/einride/sage/pull/573/commits/c82e83d0171cf806a2ebd6378324d5ce268bdae9)")

- Feedback was it looked complex. I simplified a bit so now the `key` and `restore-keys` values are just populated inline. A caveat of this approach is that each branch will produce a new cache. Risk for disk space blowing up and that we exceed the included disk space shown in https://github.com/organizations/einride/settings/billing (I don't have access there).

#### Also...

- Remove excessive fallback `restore_keys` values. This is rather unconventional but after discussions we decided we either wanted a 100% match from Go version + `go.sum` to get a cache hit. If not, we would rather see no cache hit.
- Bonus: add `./sage/build` folder to cache (forgot this in earlier PR).
- Bonus: add issue link to why we disabled the `actions/go-setup` cache in #571.



### Notes

#### Try it out without merging this PR

We should try this in some repo by setting this temporarily:

```diff
    steps:
      - name: Setup Sage
-        uses: einride/sage/actions/setup@master
+        uses: einride/sage/actions/setup@dynamic-cache-keys
```

#### Do not forget to trigger cache creation in master

...to build the cache in the `master` branch.

```yaml
on:
  push:
    branches:
      - master
  pull_request:
```

or something like:

```yaml
on: push
```

#### Further improvement

When the first commit of a PR is pushed, the cache from `master` will be used. But at the end of the run, a new cache (for the PR) is written which takes around 1 minute in our larger repos with  ~1.7 GB of cache.

To shave off this minute in GHA and avoid exploding disk spage usage, we can opt in to only _writing_ cache from `master` and only _read_ cache from the PR. 

```yml
jobs:
  job_name:
    steps:
      - name: Restore cache
        if: ${{ inputs.disableCache != 'true' }}
        uses: actions/cache/restore@v4
        with:
          path: |
            ./.sage/build
            ./.sage/tools
            ./.sage/bin
            /home/runner/.cache/go-build
            /home/runner/go/pkg/mod
            /home/runner/go/bin
          key: ${{ runner.os }}-${{ github.ref_name }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
          restore-keys: |
            ${{ runner.os }}-${{ github.base_ref }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}

      # Other steps in the job would go here, like running 'make'

      - name: Save cache
        if: ${{ inputs.disableCache != 'true' && (github.ref_name == 'master' || github.ref_name == 'main') }}
        uses: actions/cache/save@v4
        with:
          path: |
            ./.sage/build
            ./.sage/tools
            ./.sage/bin
            /home/runner/.cache/go-build
            /home/runner/go/pkg/mod
            /home/runner/go/bin
          key: ${{ runner.os }}-${{ github.ref_name }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
```

See here:
- https://github.com/actions/cache#using-a-combination-of-restore-and-save-actions
- https://github.com/actions/cache/blob/main/caching-strategies.md#saving-cache-once-and-reusing-in-multiple-workflows

However, this requires breaking up this workflow into two workflows. Or create a post job, which I haven't done before, but seems [possible](https://dev.to/abiwinanda/github-action-adding-post-steps-in-composite-actions-5ak3) although mighty quirky.

Either way, any of those methods looks like non-trivial changes to me, and I believe this PR (as it stands right now) balances the low-effort change with major impact quite nicely. The only question I would like to discuss is [this](https://github.com/einride/sage/pull/573#pullrequestreview-2247056724).

We could add the following, which would also further lower the amount of disk space used by PR cache: https://github.com/actions/cache/blob/main/tips-and-workarounds.md#force-deletion-of-caches-overriding-default-cache-eviction-policy