### PR TITLE
fix(gha): prevent runner from traversing entire repository

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -58,6 +58,7 @@ runs:
           /home/runner/.cache/go-build
           /home/runner/go/pkg/mod
           /home/runner/go/bin
-        key: ${{ runner.os }}-${{ github.ref_name }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
+        # NOTE: do not use **/go.sum because: https://github.com/actions/runner/issues/449
+        key: ${{ runner.os }}-${{ github.ref_name }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('go.sum', '*/go.sum') }}
         restore-keys: |
-          ${{ runner.os }}-${{ github.base_ref }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
+          ${{ runner.os }}-${{ github.base_ref }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('go.sum', '*/go.sum') }}


### PR DESCRIPTION
### Why this change?

We have seen issues where the runner does not have permissions to enter a certain directory. Then the post-step of the cache will fail in GHA. Related issue: https://github.com/actions/checkout/issues/760

The reason for this is that a container is running in GHA and uses root permissions when writing files into GHA.

### What was done?

Do not look for `go.sum` files throughout the entire repository. Just search one folder deeper than the root.

### Notes, side-effects etc

- If no go.sum is found, I'm not sure what will happen here...
- It is unclear to me why the runner does not have access to enter the directory. Might be a good idea to figure out if the problem we need to fix lies there instead.
- We are not alone: https://github.com/actions/runner/issues/449