### PR TITLE
fix(gha): allow opt-out of **/go.sum repo traversal

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -2,11 +2,6 @@ name: Setup Sage
 description: Setup Sage, including caching of tools and Go modules.
 
 inputs:
-  cacheKey:
-    description: Custom cache key used
-    required: false
-    default: cachekey
-
   disableCache:
     description: Disable cache
     required: false
@@ -16,6 +11,13 @@ inputs:
     description: The Go version to download (if necessary) and use. Supports semver spec and ranges.
     required: false
     default: '1.22'
+
+  cacheKey:
+    description: Custom cache key used
+    required: false
+    # NOTE: some projects cannot use **/go.sum because: https://github.com/actions/runner/issues/449
+    # In such cases, try providing the cache key and set it to e.g. ${{ hashFiles('go.sum', '*/go.sum') }} instead
+    default: ${{ hashFiles('**/go.sum') }}
 
   check-latest:
     description: If true, checks whether the cached go version is the latest, if not then downloads the latest. Useful when you need to use the latest version.
@@ -58,6 +60,7 @@ runs:
           /home/runner/.cache/go-build
           /home/runner/go/pkg/mod
           /home/runner/go/bin
-        key: ${{ runner.os }}-${{ github.ref_name }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
+
+        key: ${{ runner.os }}-${{ github.ref_name }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.go-version }}-${{ inputs.cacheKey }}
         restore-keys: |
-          ${{ runner.os }}-${{ github.base_ref }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.cacheKey }}-${{ inputs.go-version }}-${{ hashFiles('**/go.sum') }}
+          ${{ runner.os }}-${{ github.base_ref }}-${{ github.workflow }}-${{ github.job }}-${{ inputs.go-version }}-${{ inputs.cacheKey }}


### PR DESCRIPTION
## Why this change?

We have seen issues where the runner does not have permissions to enter a
certain directory. Then the post-step of the cache will fail in GHA.

The reason is that `hashfiles` currently traverses the entire repository.


## What was changed?

- Move the `hashfiles` entry, which is part of the cache key to become opt-out.

## Notes

- This PR supersedes #576
