### PR TITLE
feat(golangcilint): enable spancheck linter

### DIFF
--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -194,6 +194,10 @@ linters:
     # [fast: true, auto-fix: false]
     - usestdlibvars
 
+    # Checks for mistakes with OpenTelemetry/Census spans.
+    # [fast: false, auto-fix: false]
+    - spancheck
+
 linters-settings:
   gomodguard:
     blocked:


### PR DESCRIPTION
Checks for common OpenTelemetry mistakes.