### PR TITLE
feat(golangcilint): replace exportloopref with copyloopvar

### DIFF
--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -18,6 +18,10 @@ linters:
     # [fast: false, auto-fix: false]
     - bodyclose
 
+    # Copyloopvar is a linter detects places where loop variables are copied.
+    # [fast: false, auto-fix: false]
+    - copyloopvar
+
     # Check for two durations multiplied together.
     # [fast: false, auto-fix: false]
     - durationcheck
@@ -33,10 +37,6 @@ linters:
     # Find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
     # [fast: false, auto-fix: false]
     - errorlint
-
-    # Check for pointers to enclosing loop variables.
-    # [fast: false, auto-fix: false]
-    - exportloopref
 
     # Check package import order and make it always deterministic.
     # [fast: true, auto-fix: true]


### PR DESCRIPTION
We currently get the following warning when running the linter:
"The linter 'exportloopref' is deprecated (since v1.60.2) due to:
Since Go1.22 (loopvar) this linter is no longer relevant. Replaced by copyloopvar."
