### PR TITLE
feat(sgcspevaluatorcli): add csp helper type

### DIFF
--- a/tools/sgcspevaluatorcli/csp.go
+++ b/tools/sgcspevaluatorcli/csp.go
@@ -1,0 +1,80 @@
+package sgcspevaluatorcli
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ContentSecurityPolicy is a map where each key is a Content Security Policy directive,
+// and value is a list of sources for the respective directive.
+type ContentSecurityPolicy map[string][]string
+
+// String returns ContentSecurityPolicy ready to be send as a HTTP header.
+func (csp ContentSecurityPolicy) String() string {
+	directives := make([]string, 0, len(csp))
+	for directive, rules := range csp {
+		sort.Slice(rules, func(i, j int) bool { return rules[i] < rules[j] })
+		directives = append(directives, fmt.Sprintf("%s %s", directive, strings.Join(rules, " ")))
+	}
+	sort.Slice(directives, func(i, j int) bool { return directives[i] < directives[j] })
+	return strings.Join(directives, "; ")
+}
+
+// Clone returns a deep copy of the content security policy.
+func (csp ContentSecurityPolicy) Clone() ContentSecurityPolicy {
+	cloned := map[string][]string{}
+	for key, values := range csp {
+		cloned[key] = make([]string, len(values))
+		copy(cloned[key], values)
+	}
+	return cloned
+}
+
+// With returns a new content security policy with an additional directive and sources.
+//
+// Note that the _new_ policy is returned here, so changing the returned value from this function will
+// not change original policy.
+func (csp ContentSecurityPolicy) With(directive, source string, sources ...string) ContentSecurityPolicy {
+	clone := csp.Clone()
+	clone[directive] = appendUnique(clone[directive], append(sources, source))
+	return clone
+}
+
+// Merge returns a new union policy.
+func (csp ContentSecurityPolicy) Merge(other ...ContentSecurityPolicy) ContentSecurityPolicy {
+	var merged ContentSecurityPolicy = map[string][]string{}
+	for _, policy := range append(other, csp) {
+		for directive, sources := range policy {
+			switch len(sources) {
+			case 0:
+			case 1:
+				merged = merged.With(directive, sources[0])
+			default:
+				merged = merged.With(directive, sources[0], sources[1:]...)
+			}
+		}
+	}
+	return merged
+}
+
+func appendUnique(ll ...[]string) []string {
+	set := map[string]struct{}{}
+	for _, l := range ll {
+		for _, item := range l {
+			set[item] = struct{}{}
+		}
+	}
+	return sortedKeys(set)
+}
+
+func sortedKeys(m map[string]struct{}) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Slice(keys, func(i, j int) bool {
+		return keys[i] < keys[j]
+	})
+	return keys
+}

--- a/tools/sgcspevaluatorcli/csp_test.go
+++ b/tools/sgcspevaluatorcli/csp_test.go
@@ -1,0 +1,94 @@
+package sgcspevaluatorcli_test
+
+import (
+	"strings"
+	"testing"
+
+	"go.einride.tech/sage/tools/sgcspevaluatorcli"
+)
+
+func TestContentSecurityPolicy_Clone(t *testing.T) {
+	var policy sgcspevaluatorcli.ContentSecurityPolicy = map[string][]string{
+		"directive": {"source"},
+	}
+	cloned := policy.Clone()
+
+	cloned.With("new directive", "source one")
+	cloned.With("directive", "source two")
+
+	if len(policy) != 1 {
+		t.Fatalf("changing cloned policy should not change source policy")
+	}
+
+	assertSources(t, policy, "directive", "source")
+}
+
+func TestContentSecurityPolicy_With(t *testing.T) {
+	policy := new(sgcspevaluatorcli.ContentSecurityPolicy).
+		With("directive", "source").
+		With("directive", "source")
+
+	assertSources(t, policy, "directive", "source")
+}
+
+func TestContentSecurityPolicy_String(t *testing.T) {
+	policy := new(sgcspevaluatorcli.ContentSecurityPolicy).
+		With("directive", "source").
+		With("another directive", "source1", "source2")
+
+	expected := "another directive source1 source2; directive source"
+	if got := policy.String(); got != expected {
+		t.Fatalf("expected %q, got %q", expected, got)
+	}
+}
+
+func TestContentSecurityPolicy_Merge(t *testing.T) {
+	policy1 := new(sgcspevaluatorcli.ContentSecurityPolicy).
+		With("directive", "source")
+	policy2 := new(sgcspevaluatorcli.ContentSecurityPolicy).
+		With("directive", "source1").
+		With("directive2", "source")
+
+	merged := policy1.Merge(policy2)
+
+	if len(merged) != 2 {
+		t.Fatalf("expected merged to have 2 directved")
+	}
+
+	assertSources(t, merged, "directive", "source", "source1")
+	assertSources(t, merged, "directive2", "source")
+}
+
+func assertDirectiveExists(t *testing.T, policy sgcspevaluatorcli.ContentSecurityPolicy, directive string) {
+	t.Helper()
+
+	if _, ok := policy[directive]; !ok {
+		t.Fatalf("directive %q is missing", directive)
+	}
+}
+
+func assertSources(t *testing.T, policy sgcspevaluatorcli.ContentSecurityPolicy, directive string, sources ...string) {
+	t.Helper()
+
+	assertDirectiveExists(t, policy, directive)
+
+	if len(policy[directive]) != len(sources) {
+		t.Fatalf("unexpected number of sources: got %d, expected %d", len(policy[directive]), len(sources))
+	}
+
+	expected := make(map[string]bool, len(sources))
+	for _, source := range sources {
+		expected[source] = true
+	}
+
+	missingSources := make([]string, 0, len(sources))
+	for _, source := range policy[directive] {
+		if !expected[source] {
+			missingSources = append(missingSources, source)
+		}
+	}
+
+	if len(missingSources) != 0 {
+		t.Fatalf("directive %q missing sources %q", directive, strings.Join(missingSources, ", "))
+	}
+}

--- a/tools/sgcspevaluatorcli/tools.go
+++ b/tools/sgcspevaluatorcli/tools.go
@@ -16,6 +16,10 @@ const name = "csp"
 //go:embed package.json
 var packageJSONContent []byte
 
+func Validate(ctx context.Context, policy ContentSecurityPolicy) *exec.Cmd {
+	return Command(ctx, "validate", policy.String())
+}
+
 func Command(ctx context.Context, args ...string) *exec.Cmd {
 	sg.Deps(ctx, PrepareCommand)
 	return sg.Command(ctx, sg.FromBinDir(name), args...)


### PR DESCRIPTION
ContentSecurityPolicy type provides a set of helper functions to define content security policy in a structured way.