### PR TITLE
sgcloudrun: avoid creds.json conflict

### DIFF
--- a/sg/exec.go
+++ b/sg/exec.go
@@ -24,8 +24,7 @@ func ContextWithEnv(ctx context.Context, env ...string) context.Context {
 
 // Command should be used when returning exec.Cmd from tools to set opinionated standard fields.
 func Command(ctx context.Context, path string, args ...string) *exec.Cmd {
-	// TODO: use exec.CommandContext when we have determined there are no side-effects.
-	cmd := exec.Command(path)
+	cmd := exec.CommandContext(ctx, path)
 	cmd.Args = append(cmd.Args, args...)
 	cmd.Dir = FromGitRoot(".")
 	cmd.Env = os.Environ()


### PR DESCRIPTION
if two processes run LocalDevelopment command, they should use
different credes.json to avoid conflict.

also adds support for context cancellation when CTRL-C detected.
