### PR TITLE
GolangCI Lint runs for all targets

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -63,12 +63,11 @@ func Run(ctx context.Context, args ...string) error {
 	}); err != nil {
 		return err
 	}
+	errs := make([]error, 0, len(commands))
 	for _, cmd := range commands {
-		if err := cmd.Wait(); err != nil {
-			return err
-		}
+		errs = append(errs, cmd.Wait())
 	}
-	return nil
+	return errors.Join(errs...)
 }
 
 // Run GolangCI-Lint --fix in every Go module from the root of the current git repo.


### PR DESCRIPTION
Before this PR Sage Golangci-Lint would run for all sub folders where a go.mod is found and terminate when the first command returns an errors, could be a lint issue or some other error.
After Golangci-Lint will run for all sub folders and will run for all projects and join all errors together.