### PR TITLE
feat(ko): bump to 0.16.0

### DIFF
--- a/tools/sgko/tools.go
+++ b/tools/sgko/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "ko"
-	version = "0.15.4"
+	version = "0.16.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
When looking into container security findings I just noticed there's a newer
version of ko which we might want to use?

https://github.com/ko-build/ko/releases/tag/v0.16.0
