### PR TITLE
feat(buf): bump to latest version

### DIFF
--- a/tools/sgbuf/tools.go
+++ b/tools/sgbuf/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "1.35.1"
+	version = "1.44.0"
 	name    = "buf"
 )
 


### PR DESCRIPTION
### Why this change?

Let's just keep up to date!
Buf is getting an lsp! 🎉 

### What?

- Bump it!

### Notes


Please note that in v1.40.0 they deprecated the `buf lint` ruleset from `DEFAULT` to `STANDARD`. You'll see this warning:

```
❯ buf lint --verbose
WARN    Category DEFAULT referenced in your buf.yaml is deprecated. It has been replaced by category STANDARD.

        The concept of a default rule has been introduced. A default rule is a rule that will be run
        if no rules are explicitly configured in your buf.yaml. Run buf config ls-lint-rules or
        buf config ls-breaking-rules to see which rules are defaults. With this introduction, having a category
        also named DEFAULT is confusing, as while it happpens that all the rules in the DEFAULT category
        are also default rules, the name has become overloaded.

        As with all buf changes, this change is backwards-compatible: DEFAULT will continue to work.
        We recommend replacing DEFAULT in your buf.yaml, but no action is immediately necessary.
```