### PR TITLE
fix(cloud-spanner): stop emulator container with background context

### DIFF
--- a/tools/sgcloudspanner/emulator.go
+++ b/tools/sgcloudspanner/emulator.go
@@ -44,6 +44,8 @@ func RunEmulator(ctx context.Context) (_ func(), err error) {
 	}
 	containerID := strings.TrimSpace(dockerRunStdout.String())
 	cleanup := func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
 		sg.Logger(ctx).Println("stopping down Cloud Spanner emulator...")
 		cmd := sgdocker.Command(ctx, "kill", containerID)
 		cmd.Stdout, cmd.Stderr = nil, nil


### PR DESCRIPTION
Use a background context with a 10s timeout when stopping the emulator.

This makes sure the container is (at least attempted) stopped when e.g. pressing ctrl-c while running tests.