### PR TITLE
feat(spanner): bump to 1.5.22

### DIFF
--- a/tools/sgcloudspanner/emulator.go
+++ b/tools/sgcloudspanner/emulator.go
@@ -17,7 +17,7 @@ import (
 // https://console.cloud.google.com/gcr/images/cloud-spanner-emulator/global/emulator
 const (
 	url     = "gcr.io/cloud-spanner-emulator/emulator"
-	version = "1.5.17"
+	version = "1.5.22"
 	image   = url + ":" + version
 )
 


### PR DESCRIPTION
I'm not bumping all the way to 1.5.24 as we are seeing issues with Spanner on
macOS on versions released after 1.5.22.

I've added a note on this limitation/issue in our internal macOS tech-radar.

We should investigate and perhaps file an issue with
https://github.com/GoogleCloudPlatform/cloud-spanner-emulator
