### PR TITLE
feat(sgprotocgengoaiptest): bump to v0.27.0

### DIFF
--- a/tools/sgprotocgengoaiptest/tools.go
+++ b/tools/sgprotocgengoaiptest/tools.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	version = "0.24.1"
+	version = "0.27.0"
 	name    = "protoc-gen-go-aip-test"
 )
 


### PR DESCRIPTION
Version 0.27.0 introduces a new way to bootstrap AIP tests, see https://github.com/einride/protoc-gen-go-aip-test/pull/263 for more info.