### PR TITLE
feat(trivy): bump to v0.56.2

### DIFF
--- a/tools/sgtrivy/tools.go
+++ b/tools/sgtrivy/tools.go
@@ -18,7 +18,7 @@ import (
 var defaultConfig []byte
 
 const (
-	version = "0.56.1"
+	version = "0.56.2"
 	name    = "trivy"
 )
 

--- a/tools/sgtrivy/tools.go
+++ b/tools/sgtrivy/tools.go
@@ -18,7 +18,7 @@ import (
 var defaultConfig []byte
 
 const (
-	version = "0.52.1"
+	version = "0.56.1"
 	name    = "trivy"
 )
 


### PR DESCRIPTION
Looks like trivy was updated so that we can remove the ignore-comments about ssl
mode.

- https://github.com/aquasecurity/trivy-checks/releases/tag/v1.1.0
- https://github.com/aquasecurity/trivy/releases/tag/v0.56.0 (note the
  chore(deps): Bump trivy-checks to v1.1.0)

But I also noticed that https://github.com/aquasecurity/trivy/pull/7564 is not
merged yet, so not really 100% sure about this.
