### PR TITLE
feat(sgcloudendpoints): bump to esp-v2 2.50.0

### DIFF
--- a/tools/sgcloudendpoints/tools.go
+++ b/tools/sgcloudendpoints/tools.go
@@ -18,7 +18,7 @@ import (
 )
 
 // espVersion is the version of ESPv2 used for building images.
-const espVersion = "2.49.0"
+const espVersion = "2.50.0"
 
 //go:embed Dockerfile
 var dockerfile []byte


### PR DESCRIPTION
Reference:
https://github.com/GoogleCloudPlatform/esp-v2/releases/tag/v2.50.0
