### PR TITLE
feat(sgprotocgengoaiptest): bump to v0.28.0

### DIFF
--- a/tools/sgprotocgengoaiptest/tools.go
+++ b/tools/sgprotocgengoaiptest/tools.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	version = "0.27.0"
+	version = "0.28.0"
 	name    = "protoc-gen-go-aip-test"
 )
 


### PR DESCRIPTION
Introduces a new way to invoke the AIP tests, see this [PR](https://github.com/einride/protoc-gen-go-aip-test/pull/267).

Beware that this version will generate new test code.