### PR TITLE
feat(sgmdformat): lock the version of the tool

### DIFF
--- a/tools/sgmdformat/requirements.txt
+++ b/tools/sgmdformat/requirements.txt
@@ -1,3 +1,4 @@
+mdformat==0.7.19
 mdformat-gfm==0.3.7
 mdformat-admon==2.0.6
 mdformat-frontmatter==2.0.8


### PR DESCRIPTION
Allows dependabot to also keep up with the version of the tool and
prevents surprise bumps when being run in various repositories
