### PR TITLE
feat(sgprettier): don't fail when filetype not found.

### DIFF
--- a/tools/sgprettier/tools.go
+++ b/tools/sgprettier/tools.go
@@ -40,8 +40,7 @@ func FormatGoTemplates(ctx context.Context) *exec.Cmd {
 		"--parser",
 		"go-template",
 		"--write",
-		"**/*.html",
-		"**/*.tmpl",
+		"**/*.{html,tmpl}",
 		"!" + sg.FromSageDir(),
 	}
 	return Command(ctx, args...)


### PR DESCRIPTION
This change should make it so pretiier does not return an error when a certain filetype is not found.