### PR TITLE
feat(golangcilint): lint wire files

### DIFF
--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -1,5 +1,7 @@
 run:
   timeout: 10m
+  build-tags:
+    - wireinject
 
 issues:
   fix: false


### PR DESCRIPTION
[Wire](https://github.com/google/wire) is used a lot in our organization, but the linter is skipping all `wire.go` files due to them having a mandatory build tag.

This includes the build tag when running the linter, to make sure `wire.go` files are linted as well.

I would expect linter to break a lot of repos now, but likely with very easy fixes. Example:

```
❯ make go-lint
[sage] building binary and generating Makefiles...
[go-lint] running...
[go-lint]
internal/app/server/wire.go:61: File is not `gci`-ed with --skip-generated -s standard -s default (gci)
internal/app/server/wire.go:63: File is not `gci`-ed with --skip-generated -s standard -s default (gci)
[ ... code ... ]
internal/app/server/wire.go:62: File is not `gofumpt`-ed with `-extra` (gofumpt)
[ ... code ... ]
internal/app/server/wire.go:47:11: unused-parameter: parameter 'ctx' seems to be unused, consider removing or renaming it as _ (revive)
func Init(ctx context.Context, config *Config) (*App, func(), error) {
```