### PR TITLE
feat: bump downloaded go to version 1.23.4

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ sagefile := $(abspath $(cwd)/.sage/bin/sagefile)
 go := $(shell command -v go 2>/dev/null)
 export GOWORK ?= off
 ifndef go
-SAGE_GO_VERSION ?= 1.20.2
+SAGE_GO_VERSION ?= 1.23.4
 export GOROOT := $(abspath $(cwd)/.sage/tools/go/$(SAGE_GO_VERSION)/go)
 export PATH := $(PATH):$(GOROOT)/bin
 go := $(GOROOT)/bin/go

--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -15,7 +15,7 @@ import (
 	"go.einride.tech/sage/internal/strcase"
 )
 
-const defaultGoVersion = "1.20.2"
+const defaultGoVersion = "1.23.4"
 
 type Makefile struct {
 	Namespace     interface{}


### PR DESCRIPTION
If Sage is invoked in an environment where Go is not available in `$PATH`, Sage will download it.

This should not affect any users that has Go installed outside of an Sage repo.
