### PR TITLE
fix: use proper binary name for v2+ modules

### DIFF
--- a/sgtool/build.go
+++ b/sgtool/build.go
@@ -49,7 +49,17 @@ func GoInstallWithModfile(ctx context.Context, pkg, file string) (string, error)
 	if version == "" {
 		return "", fmt.Errorf("failed to determine version of package %s", pkg)
 	}
-	executable := sg.FromToolsDir("go", pkg, version, filepath.Base(pkg))
+
+	var b2 bytes.Buffer
+	cmd = sg.Command(ctx, "go", "list", "-f", "{{.Target}}", pkg)
+	cmd.Stdout = &b2
+	cmd.Dir = filepath.Dir(file)
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+	commandName := filepath.Base(strings.TrimSpace(b2.String()))
+
+	executable := sg.FromToolsDir("go", pkg, version, commandName)
 	// Check if executable already exist
 	if _, err := os.Stat(executable); err == nil {
 		symlink, err := CreateSymlink(executable)


### PR DESCRIPTION
When installing a go module which has made a major version bump,
e.g. example.com/foo => example.com/foo/v2,
just looking at the last element of the path to get the binary name
returns "v2" instead of "foo" (which is what 'go install' will name
the binary).

Instead use a 'go list' helper function to determine the name.
