### PR TITLE
feat(sggolangcilint): bump from v1.62.0 to v1.63.4

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.62.0"
+	version = "1.63.4"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
See changes [here](https://github.com/golangci/golangci-lint/releases)