### PR TITLE
feat(golangci-lint): bump to 1.64.2

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.63.4"
+	version = "1.64.2"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Supports Go 1.24 among other things:
https://github.com/golangci/golangci-lint/releases/tag/v1.64.2