### PR TITLE
fix(convco): downgrade to v0.6.1

### DIFF
--- a/tools/sgconvco/tools.go
+++ b/tools/sgconvco/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "convco"
-	version = "0.6.2"
+	version = "0.6.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
v0.6.2 is built against glibc 2.39 whereas v0.6.1 is built against 2.34. This means that v0.6.2 is not compatible with Debian bookworm machines, but v0.6.1 is.

TL;DR: downgrade to keep compatiblity with "older" Linux dists