### PR TITLE
fix(golangci-lint): bump to v1.64.4

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.64.2"
+	version = "1.64.4"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Seems to iron out some kinks related to Go 1.24.

Changelog:
https://github.com/golangci/golangci-lint/releases/tag/v1.64.3 https://github.com/golangci/golangci-lint/releases/tag/v1.64.4