### PR TITLE
fix(CODEOWNERS): remove overlapping group

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @einride/platform-engineering @einride/open-source-maintainers
+* @einride/open-source-maintainers


### PR DESCRIPTION
We're (almost) all part of the latter group, and for some reason that makes me get double notifications for all PRs...

I guess we could organize the groups somehow so that the former group members are always included in the latter group?

For @alethenorio to review 😄 