### PR TITLE
fix(golangci-lint): bump to v1.64.5

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.64.4"
+	version = "1.64.5"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Another day, another golangci-lint release:
https://github.com/golangci/golangci-lint/releases/tag/v1.64.5