### PR TITLE
Add support to run `gopls check`

### DIFF
--- a/tools/sggopls/tools.go
+++ b/tools/sggopls/tools.go
@@ -1,0 +1,32 @@
+package sggopls
+
+import (
+	"context"
+	"os/exec"
+
+	"go.einride.tech/sage/sg"
+	"go.einride.tech/sage/sgtool"
+)
+
+const (
+	name    = "gopls"
+	version = "v0.17.1"
+)
+
+// Check runs `gopls check <PATH1> <PATH2>`.
+// gopls only works with paths to go files.
+func Check(ctx context.Context, paths []string) *exec.Cmd {
+	sg.Deps(ctx, PrepareCommand)
+	args := []string{"check"}
+	args = append(args, paths...)
+	return sg.Command(
+		ctx,
+		name,
+		args...,
+	)
+}
+
+func PrepareCommand(ctx context.Context) error {
+	_, err := sgtool.GoInstall(ctx, "golang.org/x/tools/gopls", version)
+	return err
+}


### PR DESCRIPTION
[gopls](https://pkg.go.dev/golang.org/x/tools/gopls) supports running as a linter through the CLi with `gopls check <PATH_TO_GO_FILE> ...`