### PR TITLE
feat(api-linter): bump to v1.69.1

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.67.2"
+	version = "1.69.1"
 	name    = "api-linter"
 )
 


### PR DESCRIPTION
This adds and fixes some AIP linters.

## Warning

[v1.68.0](https://github.com/googleapis/api-linter/releases/tag/v1.68.0) says:

> update to min version to Go 1.22 (#1457) (f34f16b)

Could this be a blocker for upgrading sage on projects which are on Go < v.22 😬
