### PR TITLE
fix: remove GOROOT from go-licenses

### DIFF
--- a/tools/sggolicenses/tools.go
+++ b/tools/sggolicenses/tools.go
@@ -44,16 +44,6 @@ func CheckDir(ctx context.Context, directory string, disallowedTypes ...string) 
 	}
 	cmd := Command(ctx, args...)
 	cmd.Dir = directory
-	// go-licenses tries to exclude standard library packages by checking if they are prefixed
-	// with `runtime.GOROOT()`. However, if the go-licenses tool is not run with a GOROOT environment variable,
-	// that call will return the GOROOT path used during build time of go-licenses. This typically works on Linux,
-	// but on macOS with Homebrew, the GOROOT is version prefixed, which breaks as soon as Go is upgraded.
-	// For example: /opt/homebrew/Cellar/go/1.19.4/libexec
-	//
-	// As a workaround, add the GOROOT environment variable to the result of `runtime.GOROOT()` called here.
-	// This should work as the Sage binary is built on the same machine that executes it.
-	// See: https://github.com/google/go-licenses/issues/149
-	cmd.Env = append(cmd.Env, fmt.Sprintf("GOROOT=%s", runtime.GOROOT()))
 	return cmd.Run()
 }
 


### PR DESCRIPTION
### Why?

In #639 I noticed a gopls warning:

```
[go-pls] Linting Go files with gopls...
[go-pls] 
/Users/fredrik/code/work/public/sage/tools/sggolicenses/tools.go:56:53-67: runtime.GOROOT is deprecated: The root used during the Go build will not be meaningful if the binary is copied to another machine. Use the system path t
o locate the “go” binary, and use “go env GOROOT” to find its GOROOT.
/Users/fredrik/code/work/public/sage/tools/sggolicenses/tools.go:100:54-68: runtime.GOROOT is deprecated: The root used during the Go build will not be meaningful if the binary is copied to another machine. Use the system path 
to locate the “go” binary, and use “go env GOROOT” to find its GOROOT.
```

### What?

I removed the line setting the GOROOT env var.

### Notes

@alethenorio I believe you originally wrote this?

https://github.com/einride/sage/blob/ea6326b1a84a8551b58b380d000c56bb37496cf0/tools/sggolicenses/tools.go#L47-L56

Please have a look :smile:

