### PR TITLE
fix(sgapilinter): include proto path

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -95,6 +95,7 @@ func Run(ctx context.Context, args ...string) error {
 						"--output-format", "json",
 						"--descriptor-set-in", descriptorFile,
 						"--config", configPath,
+						"--proto-path", moduleDir,
 					},
 					args...,
 				),


### PR DESCRIPTION
In https://github.com/googleapis/api-linter/releases/tag/v1.69.0
there was a breaking change to the api-linter's cli: it stopped
including current working directory as the proto path.
So it needs to be added here.
