### PR TITLE
feat(sgapilinter): bump and revert

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -95,7 +95,6 @@ func Run(ctx context.Context, args ...string) error {
 						"--output-format", "json",
 						"--descriptor-set-in", descriptorFile,
 						"--config", configPath,
-						"--proto-path", moduleDir,
 					},
 					args...,
 				),

--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.69.1"
+	version = "1.69.2"
 	name    = "api-linter"
 )
 


### PR DESCRIPTION
### Why?

With api-linter v1.69.1, there was a side-effect/bug introduced which required us to add `--proto-path=.` to keep api-linter working. This side-effect/bug was fixed in v1.69.2.

We can keep `--proto-path=.` or remove it (hence the two separate commits) without issues, but I figured we should remove it.


### What?

- **feat(sgapilinter): bump with bugfix**
- **fix(sgapilinter): revert "include proto path"**

### Notes

- https://github.com/googleapis/api-linter/releases/tag/v1.69.2
- https://github.com/googleapis/api-linter/issues/1465#issuecomment-2672414331