### PR TITLE
feat(sgosvscanner): bump to v1.9.2

### DIFF
--- a/tools/sgosvscanner/tools.go
+++ b/tools/sgosvscanner/tools.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	version    = "1.0.2"
+	version    = "1.9.2"
 	binaryName = "osv-scanner"
 )
 
@@ -28,8 +28,7 @@ func PrepareCommand(ctx context.Context) error {
 	if err := sgtool.FromRemote(
 		ctx,
 		fmt.Sprintf(
-			"https://github.com/google/osv-scanner/releases/download/v%s/osv-scanner_%s_%s_%s",
-			version,
+			"https://github.com/google/osv-scanner/releases/download/v%s/osv-scanner_%s_%s",
 			version,
 			runtime.GOOS,
 			runtime.GOARCH,


### PR DESCRIPTION
If approved this PR:
* Bumps osv-scanner tool to [latest version](https://github.com/google/osv-scanner/releases).

The sg tool hasn't been updated in some time and I'm running into issues using this for projects with patch go versions, as current version won't parse format `go 1.xx.xx` in `go.mod` and requires format `go 1.xx`. Works with newer versions of osv-scanner.