### PR TITLE
Use Go 1.17 in CI

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Setup Sage
         uses: ./actions/setup
+        with:
+          go-version: 1.17
 
       - name: Make
         run: make

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 
 	"go.einride.tech/sage/sg"
 	"go.einride.tech/sage/sgtool"
@@ -47,6 +48,22 @@ func CommandInDirectory(ctx context.Context, directory string, args ...string) *
 	return cmd
 }
 
+func joinErrorMessages(errs []error) error {
+	var messages []string
+
+	for _, err := range errs {
+		if err != nil {
+			messages = append(messages, err.Error())
+		}
+	}
+
+	if len(messages) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("multiple errors occurred:\n%s", strings.Join(messages, "\n"))
+}
+
 // Run GolangCI-Lint in every Go module from the root of the current git repo.
 func Run(ctx context.Context, args ...string) error {
 	var commands []*exec.Cmd
@@ -67,7 +84,7 @@ func Run(ctx context.Context, args ...string) error {
 	for _, cmd := range commands {
 		errs = append(errs, cmd.Wait())
 	}
-	return errors.Join(errs...)
+	return joinErrorMessages(errs)
 }
 
 // Run GolangCI-Lint --fix in every Go module from the root of the current git repo.


### PR DESCRIPTION
### Why?

If I'm not mistaken, the idea is that Sage should be compatible with Go projects
written with Go 1.17, given the contents of the `go.mod` file:

https://github.com/einride/sage/blob/master/go.mod#L3

However, there is code in the repo which requires newer Go versions.

### What?

- [x] Use Go v1.17 in CI, so to surface the warnings/errors which needs fixing.
- [x] Do not use `errors.Join` (introduced in Go 1.20)
- [ ] Do not use `math/rand/v2` (introduced in Go 1.22)
- [ ] ...


### Notes

- Related; we might opt for upgrading the minimum required Go version instead: https://github.com/einride/sage/pull/648