### PR TITLE
Require Go 1.22 from now on

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -13,6 +13,8 @@ jobs:
 
       - name: Setup Sage
         uses: ./actions/setup
+        with:
+          go-version: 1.22
 
       - name: Make
         run: make

--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -1,6 +1,6 @@
 module github.com/einride/sage/.sage
 
-go 1.17
+go 1.22
 
 require go.einride.tech/sage v0.0.0-00010101000000-000000000000
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.einride.tech/sage
 
-go 1.17
+go 1.22

--- a/sg/deps.go
+++ b/sg/deps.go
@@ -22,8 +22,6 @@ func Deps(ctx context.Context, functions ...interface{}) {
 	checkedFunctions := checkFunctions(functions...)
 	var wg sync.WaitGroup
 	for i, f := range checkedFunctions {
-		i, f := i, f
-
 		dependencies := getDependencies(ctx)
 		for _, dependency := range dependencies {
 			if dependency.ID() == f.ID() {

--- a/sg/fn_test.go
+++ b/sg/fn_test.go
@@ -33,7 +33,6 @@ func TestFn_Name(t *testing.T) {
 			expected: "go.einride.tech/sage/sg.namespace.MyFunc",
 		},
 	} {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			fn := Fn(tt.fn)
 			got := fn.Name()


### PR DESCRIPTION
### Why?

If I'm not mistaken, the idea is that Sage should be compatible with Go projects
written with Go 1.17, given the contents of the `go.mod` file:

https://github.com/einride/sage/blob/master/go.mod#L3

However, there is code in the repo which requires newer Go versions.

### What?

- Bump minimum required Go version for using Sage to v1.22.
- Fix some linting issues which were required for passing CI.

### Notes

- There will be instances that Go 1.22 won't be used, like with building `gopls` for example (which is fine, and actually pretty neat):
	```
	[sggopls:prepare-command] building golang.org/x/tools/gopls@v0.18.0...
	[sggopls:prepare-command] go: golang.org/x/tools/gopls@v0.18.0 requires go >= 1.23.4; switching to go1.23.6
	```
- There are some `gopls` linting warnings we might want to consider cleaning up?
	```
	[go-pls] Linting Go files with gopls...
	[go-pls]
	/Users/fredrik/code/work/public/sage/sg/fn.go:25:16-27: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/sg/fn.go:25:37-48: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/sg/fn.go:33:14-25: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/sg/fn.go:33:35-46: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/sg/makefile.go:21:16-27: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/sg/makefile.go:23:16-27: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/sg/fn_test.go:12:12-23: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/sg/deps.go:20:45-56: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/sg/deps.go:69:49-60: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/sg/deps.go:75:34-45: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/tools/sgcspevaluatorcli/csp.go:17:3-13: sort.Slice can be modernized using slices.Sort
	/Users/fredrik/code/work/public/sage/tools/sgcspevaluatorcli/csp.go:20:2-12: sort.Slice can be modernized using slices.Sort
	/Users/fredrik/code/work/public/sage/tools/sgcspevaluatorcli/csp.go:76:2-12: sort.Slice can be modernized using slices.Sort
	/Users/fredrik/code/work/public/sage/tools/sggovulncheck/tools.go:37:4-42:5: Loop can be simplified using slices.Contains
	/Users/fredrik/code/work/public/sage/internal/codegen/file.go:65:26-37: interface{} can be replaced by any
	/Users/fredrik/code/work/public/sage/tools/sgapilinter/tools.go:184:6-24: for loop can be modernized using range over int
	```
- Related PR: https://github.com/einride/sage/pull/647