### PR TITLE
fix(golangci-lint): bump to v1.64.6

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.64.5"
+	version = "1.64.6"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
Mostly linter bumps, but changelog here:
https://github.com/golangci/golangci-lint/releases/tag/v1.64.6