### PR TITLE
ci(dependabot): update dependabot schedule to monthly


### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,29 +4,29 @@ updates:
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: github-actions
     directory: /actions/setup
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: gomod
     directory: /
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: gomod
     directory: .sage
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: pip
     directory: tools/sgmdformat
     schedule:
-      interval: weekly
+      interval: monthly
 
   - package-ecosystem: npm
     directory: tools/sgcspevaluatorcli
     schedule:
-      interval: weekly
+      interval: monthly

--- a/example/.github/dependabot.yml
+++ b/example/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: gomod
     directory: .sage
     schedule:
-      interval: weekly
+      interval: monthly


### PR DESCRIPTION
This PR was scripted to help increase the "signal vs noise" in terms of dependabot PRs.

- Change interval from weekly to monthly (if applicable)
- Remove specific day of week (if applicable)
