### PR TITLE
feat!: bump balena-cli from v18 to v21

### DIFF
--- a/tools/sgbalenacli/tools.go
+++ b/tools/sgbalenacli/tools.go
@@ -15,7 +15,7 @@ import (
 const (
 	toolName   = "balena-cli"
 	binaryName = "balena"
-	version    = "v18.2.34"
+	version    = "v21.1.0"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
Balena starts printing warnings when the CLI has not been updated for
half a year, and exits with an error if it is a year old. The current
version is now 207 days old, so we are seeing warning prints in our
builds.

The CLI has changed a bit, so some usage may need to be updated. E.g:

- Deprecate `devices` supported command in favor of `device-type list`
- Deprecate `notes` command in favor of `device note`
- Deprecate `tunnel` command in favor of `device tunnel`
- Deprecate `env` add in favor of `env set`
- Deprecate `ssh` command in favor of `device ssh`
- Deprecate `logs` command in favor of `device logs`
- Deprecate `scan` command in favor of `device detect`
- Deprecate `orgs` command in favor of `organization list`
- Deprecate `tags` command in favor of `tag list`
- Deprecate `envs` command in favor of `env list`
- Deprecate `key` commands in favor of `ssh-key`
- Deprecate `keys` command in favor of `key list`
- Deprecate `releases` command in favor of `release list`
- Deprecate `fleets` command in favor of `fleet list`
- Deprecate `api-keys` command in favor of `api-key list`
- Deprecate `devices` command in favor of `device list`

Changelogs:

- https://github.com/balena-io/balena-cli/releases/tag/v19.0.0
- https://github.com/balena-io/balena-cli/releases/tag/v20.0.0
- https://github.com/balena-io/balena-cli/releases/tag/v21.0.0
