### PR TITLE
feat(golangci): add exptostd linter

### DIFF
--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -40,6 +40,10 @@ linters:
     # [fast: false, auto-fix: false]
     - errorlint
 
+    # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
+    # [fast: ?, auto-fix: true]
+    - exptostd
+
     # Check package import order and make it always deterministic.
     # [fast: true, auto-fix: true]
     - gci

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.64.7"
+	version = "1.64.8"
 )
 
 //go:embed golangci.yml


### PR DESCRIPTION
![exptostd](https://github.com/user-attachments/assets/d852269c-08ba-43ce-8273-ea612fec05f6)
```
golang.org/x/exp/maps.Keys() can be replaced by slices.AppendSeq(make([]T, 0, len(data)), maps.Keys(data)) exptostd  [96, 21]
```

https://golangci-lint.run/usage/linters/#exptostd