### PR TITLE
feat(sgterraform): add PlanSummarized

### DIFF
--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -66,6 +66,19 @@ func CommentOnPullRequestWithPlan(ctx context.Context, prNumber, environment, pl
 }
 
 func CommentOnPRWithPlanSummarized(ctx context.Context, prNumber, environment, planFilePath string) *exec.Cmd {
+	comment := PlanSummarized(ctx, environment, planFilePath)
+	return sgghcomment.Command(
+		ctx,
+		"--pr",
+		prNumber,
+		"--signkey",
+		environment,
+		"--comment",
+		comment,
+	)
+}
+
+func PlanSummarized(ctx context.Context, environment, planFilePath string) string {
 	cmd := Command(
 		ctx,
 		"show",
@@ -119,15 +132,7 @@ func CommentOnPRWithPlanSummarized(ctx context.Context, prNumber, environment, p
 			"```markdown\nPlan is too large to show in a GitHub comment. See CI logs for details\n```",
 		)
 	}
-	return sgghcomment.Command(
-		ctx,
-		"--pr",
-		prNumber,
-		"--signkey",
-		environment,
-		"--comment",
-		comment,
-	)
+	return comment
 }
 
 func PrepareCommand(ctx context.Context) error {


### PR DESCRIPTION
Getting the github comment makes it possible to post [Workflow Job Summaries](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/workflow-commands-for-github-actions#adding-a-job-summary) in your CI, like below:

![Screenshot from 2025-03-20 18-46-21](https://github.com/user-attachments/assets/3a938f9c-8588-4d7b-a25c-42b09b08b7b9)
