### PR TITLE
feat(sggolangcilintv2): add golangci-lint v2

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -12,7 +12,7 @@ import (
 	"go.einride.tech/sage/tools/sgconvco"
 	"go.einride.tech/sage/tools/sggit"
 	"go.einride.tech/sage/tools/sggo"
-	"go.einride.tech/sage/tools/sggolangcilint"
+	"go.einride.tech/sage/tools/sggolangcilintv2"
 	"go.einride.tech/sage/tools/sggolicenses"
 	"go.einride.tech/sage/tools/sggolines"
 	"go.einride.tech/sage/tools/sggopls"
@@ -48,7 +48,10 @@ func GoTest(ctx context.Context) error {
 
 func GoLint(ctx context.Context) error {
 	sg.Logger(ctx).Println("linting Go files...")
-	return sggolangcilint.Run(ctx)
+	return sggolangcilintv2.Run(
+		ctx,
+		sggolangcilintv2.Config{RunRelativePathMode: sggolangcilintv2.RunRelativePathModeGitRoot},
+	)
 }
 
 func GoPls(ctx context.Context) error {
@@ -62,7 +65,10 @@ func GoPls(ctx context.Context) error {
 
 func GoLintFix(ctx context.Context) error {
 	sg.Logger(ctx).Println("fixing Go files...")
-	return sggolangcilint.Fix(ctx)
+	return sggolangcilintv2.Fix(
+		ctx,
+		sggolangcilintv2.Config{RunRelativePathMode: sggolangcilintv2.RunRelativePathModeGitRoot},
+	)
 }
 
 func GoFormat(ctx context.Context) error {

--- a/internal/codegen/imports.go
+++ b/internal/codegen/imports.go
@@ -99,6 +99,7 @@ func importPathToAssumedName(importPath string) string {
 	}
 	base = strings.TrimPrefix(base, "go-")
 	if i := strings.IndexFunc(base, func(r rune) bool {
+		//nolint:staticcheck // De Morgan's law intentionally not applied
 		return !('a' <= r && r <= 'z' || 'A' <= r && r <= 'Z' || '0' <= r && r <= '9' || r == '_' ||
 			r >= utf8.RuneSelf && (unicode.IsLetter(r) || unicode.IsDigit(r)))
 	}); i >= 0 {

--- a/tools/sgartifactregistry/auth.go
+++ b/tools/sgartifactregistry/auth.go
@@ -57,9 +57,9 @@ func NpmAuthenticate(ctx context.Context, packageJSONDir, registryURL string) er
 		yarnMajor = strings.Split(version, ".")[0]
 	}
 
-	switch {
+	switch yarnMajor {
 	// If yarn v1 or npm we use npm config
-	case yarnMajor == "1":
+	case "1":
 		cmd = sg.Command(
 			ctx,
 			"npm",

--- a/tools/sggolangcilintv2/golangci.yml.tmpl
+++ b/tools/sggolangcilintv2/golangci.yml.tmpl
@@ -1,0 +1,263 @@
+version: "2"
+
+run:
+  build-tags:
+    - wireinject
+  relative-path-mode: {{ .RunRelativePathMode }}
+
+issues:
+  fix: false
+
+linters:
+  default: none
+  enable:
+    # Check for pass []any as any in variadic func(...any).
+    # [fast: false, auto-fix: false]
+    - asasalint
+
+    # Check that code does not contain non-ASCII identifiers.
+    # [fast: true, auto-fix: false]
+    - asciicheck
+
+    # Checks for dangerous unicode character sequences.
+    # [fast: true]
+    - bidichk
+
+    # Check whether HTTP response body is closed successfully.
+    # [fast: false, auto-fix: false]
+    - bodyclose
+
+    # Copyloopvar is a linter detects places where loop variables are copied.
+    # [fast: false, auto-fix: false]
+    - copyloopvar
+
+    # Check for two durations multiplied together.
+    # [fast: false, auto-fix: false]
+    - durationcheck
+
+    # Check for unchecked errors. Unchecked errors can be critical bugs in some cases.
+    # [fast: false, auto-fix: false]
+    - errcheck
+
+    # Checks types passed to the json encoding functions. Reports unsupported types and reports occurrences where the check for the returned error can be omitted.
+    # [fast: false, autofix: false]
+    - errchkjson
+
+    # Check that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.
+    # [fast: false, auto-fix: false]
+    - errname
+
+    # Find code that will cause problems with the error wrapping scheme introduced in Go 1.13.
+    # [fast: false, auto-fix: false]
+    - errorlint
+
+    # Detects functions from golang.org/x/exp/ that can be replaced by std functions.
+    # [fast: ?, auto-fix: true]
+    - exptostd
+
+    # Check that no global variables exist.
+    # [fast: false, auto-fix: false]
+    - gochecknoglobals
+
+    # Check that no init functions are present in Go code.
+    # [fast: true, auto-fix: false]
+    - gochecknoinits
+
+    # Check for bugs, performance and style issues.
+    # [fast: false, auto-fix: false]
+    - gocritic
+
+    # Check if comments end in a period.
+    # [fast: true, auto-fix: true]
+    - godot
+
+    # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
+    # [fast: true, auto-fix: false]
+    - gomoddirectives
+
+    # Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations.
+    # [fast: true, auto-fix: false]
+    - gomodguard
+
+    # Check that printf-like functions are named with `f` at the end.
+    # [fast: true, auto-fix: false]
+    - goprintffuncname
+
+    # Inspects source code for security problems.
+    # [fast: false, auto-fix: false]
+    - gosec
+
+    # Report suspicious constructs, such as Printf calls whose arguments do not align with the format string.
+    # [fast: false, auto-fix: false]
+    - govet
+
+    # Detect when assignments to existing variables are not used.
+    # [fast: true, auto-fix: false]
+    - ineffassign
+
+    # Report long lines.
+    # [fast: true, auto-fix: false]
+    - lll
+
+    # Find slice declarations with non-zero initial length.
+    # [fast: false, auto-fix: false]
+    - makezero
+
+    # Find commonly misspelled English words in comments.
+    # [fast: true, auto-fix: true]
+    - misspell
+
+    # Find naked returns in functions greater than a specified function length.
+    # [fast: true, auto-fix: false]
+    - nakedret
+
+    # Find the code that returns nil even if it checks that the error is not nil.
+    # [fast: false, auto-fix: false]
+    - nilerr
+
+    # Finds sending http request without context.Context.
+    # [fast: false, auto-fix: false]
+    - noctx
+
+    # Report ill-formed or insufficient nolint directives.
+    # [fast: true, auto-fix: false]
+    - nolintlint
+
+    # Find slice declarations that could potentially be preallocated.
+    # [fast: true, auto-fix: false]
+    - prealloc
+
+    # Find code that shadows one of Go's predeclared identifiers.
+    # [fast: true, auto-fix: false]
+    - predeclared
+
+    # Check Prometheus metrics naming via promlint.
+    # [fast: true, auto-fix: false]
+    - promlinter
+
+    # Reports direct reads from proto message fields when getters should be used.
+    # [fast: false, auto-fix: true]
+    - protogetter
+
+    # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
+    # [fast: false, auto-fix: true]
+    - revive
+
+    # Check whether Err of rows is checked successfully.
+    # [fast: false, auto-fix: false]
+    - rowserrcheck
+
+    # Ensure consistent code style when using log/slog.
+    # [fast: false, auto-fix: false]
+    - sloglint
+
+    # Checks for mistakes with OpenTelemetry/Census spans.
+    # [fast: false, auto-fix: false]
+    - spancheck
+
+    # Check that sql.Rows and sql.Stmt are closed.
+    # [fast: false, auto-fix: false]
+    - sqlclosecheck
+
+    # Go vet on steroids, applying a ton of static analysis checks.
+    # [fast: false, auto-fix: false]
+    - staticcheck
+
+    # Detect inappropriate usage of t.Parallel() method in your Go test codes.
+    # [fast: false, auto-fix: false]
+    - tparallel
+
+    # Remove unnecessary type conversions.
+    # [fast: false, auto-fix: false]
+    - unconvert
+
+    # Check Go code for unused constants, variables, functions and types.
+    # [fast: false, auto-fix: false]
+    - unused
+
+    # A linter that detect the possibility to use variables/constants from the Go standard library.
+    # [fast: true, auto-fix: true]
+    - usestdlibvars
+
+    # Find wasted assignment statements.
+    # [fast: false, auto-fix: false]
+    - wastedassign
+
+    # Detect leading and trailing whitespace.
+    # [fast: true, auto-fix: true]
+    - whitespace
+  settings:
+    errorlint:
+      errorf: false
+
+    gomoddirectives:
+      replace-local: true
+
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/sirupsen/logrus:
+              recommendations:
+                - go.uber.org/zap
+              reason: Use Zap for logging.
+          - github.com/rs/zerolog:
+              recommendations:
+                - go.uber.org/zap
+              reason: Use Zap for logging.
+          - github.com/pkg/errors:
+              recommendations:
+                - errors
+                - fmt
+              reason: Use the standard library error packages.
+          - golang.org/x/xerrors:
+              recommendations:
+                - errors
+                - fmt
+              reason: Use the standard library error packages.
+          - github.com/golang/protobuf:
+              recommendations:
+                - google.golang.org/protobuf
+              reason: The protobuf v1 module is deprecated.
+          - github.com/stretchr/testify:
+              recommendations:
+                - gotest.tools/v3
+              reason: More reliably supports protobuf messages.
+
+    gosec:
+      excludes:
+        - G115
+
+    lll:
+      line-length: 120
+      tab-width: 1
+
+    misspell:
+      locale: US
+      ignore-rules:
+        - cancelled
+        - cancelling
+        - analyses
+
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: true
+
+    protogetter:
+      skip-any-generated: true
+
+    staticcheck:
+      checks:
+        - all
+
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    {{- if .LintersExclusionsPaths }}
+    paths:{{ range .LintersExclusionsPaths }}
+      - {{ . }}{{ end }}
+    {{- end }}

--- a/tools/sggolangcilintv2/tools.go
+++ b/tools/sggolangcilintv2/tools.go
@@ -1,0 +1,173 @@
+// This package is considered experimental and may change.
+
+package sggolangcilintv2
+
+import (
+	"context"
+	_ "embed"
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"text/template"
+
+	"go.einride.tech/sage/sg"
+	"go.einride.tech/sage/sgtool"
+)
+
+const (
+	name    = "golangci-lint"
+	version = "2.1.1"
+
+	RunRelativePathModeGitRoot    = "gitroot"
+	RunRelativePathModeGomod      = "gomod"
+	RunRelativePathModeCfg        = "cfg" // WARNING: not recommended; paths will be relative to .sage/tools/golangci-lint
+	RunRelativePathModeWorkingDir = "wd"  // WARNING: not recommended according to official docs
+)
+
+type RunRelativePathMode string
+
+//go:embed golangci.yml.tmpl
+var configTemplate []byte
+
+// Config holds values which will be applied to the template, ultimately resulting in the final golangci.yml file.
+type Config struct {
+	// The mode used to evaluate relative paths. It's used by exclusions, Go plugins and some linters.
+	RunRelativePathMode RunRelativePathMode
+	// Which file paths to exclude from issue reporting. The paths will still be analyzed.
+	// Golangci-Lint will:
+	// - replace "/" with the current OS file path separator to properly work on Windows.
+	// - allow you to optionally use regexps here, like ".*\\.my\\.go$".
+	// - treat paths relative to the setting of RunRelativePathMode.
+	LintersExclusionsPaths []string
+}
+
+func Command(ctx context.Context, config Config, args ...string) *exec.Cmd {
+	sg.Deps(ctx, func(ctx context.Context) error {
+		return PrepareCommand(ctx, config)
+	})
+	return sg.Command(ctx, sg.FromBinDir(name), args...)
+}
+
+func defaultConfigPath() string {
+	return sg.FromToolsDir(name, ".golangci.yml")
+}
+
+func CommandInDirectory(ctx context.Context, config Config, directory string, args ...string) *exec.Cmd {
+	configPath := filepath.Join(directory, ".golangci.yml")
+	if _, err := os.Lstat(configPath); errors.Is(err, os.ErrNotExist) {
+		configPath = defaultConfigPath()
+	}
+	cmdArgs := append([]string{"run", "--allow-parallel-runners", "-c", configPath}, args...)
+	cmd := Command(ctx, config, cmdArgs...)
+	cmd.Dir = directory
+	return cmd
+}
+
+// Run GolangCI-Lint in every Go module from the root of the current git repo.
+func Run(ctx context.Context, config Config, args ...string) error {
+	var commands []*exec.Cmd
+	if err := filepath.WalkDir(sg.FromGitRoot(), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "go.mod" {
+			return nil
+		}
+		cmd := CommandInDirectory(ctx, config, filepath.Dir(path), args...)
+		commands = append(commands, cmd)
+		return cmd.Start()
+	}); err != nil {
+		return err
+	}
+	errs := make([]error, 0, len(commands))
+	for _, cmd := range commands {
+		errs = append(errs, cmd.Wait())
+	}
+	return errors.Join(errs...)
+}
+
+// Run GolangCI-Lint --fix in every Go module from the root of the current git repo.
+func Fix(ctx context.Context, config Config, args ...string) error {
+	var commands []*exec.Cmd
+	if err := filepath.WalkDir(sg.FromGitRoot(), func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || d.Name() != "go.mod" {
+			return nil
+		}
+		cmd := Command(
+			ctx,
+			config,
+			append([]string{"run", "--allow-serial-runners", "-c", defaultConfigPath(), "--fix"}, args...)...,
+		)
+		cmd.Dir = filepath.Dir(path)
+		commands = append(commands, cmd)
+		return cmd.Start()
+	}); err != nil {
+		return err
+	}
+	for _, cmd := range commands {
+		if err := cmd.Wait(); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func PrepareCommand(ctx context.Context, config Config) error {
+	toolDir := sg.FromToolsDir(name)
+	binDir := filepath.Join(toolDir, version, "bin")
+	binary := filepath.Join(binDir, name)
+	hostOS := runtime.GOOS
+	hostArch := runtime.GOARCH
+	golangciLint := fmt.Sprintf("golangci-lint-%s-%s-%s", version, hostOS, hostArch)
+	binURL := fmt.Sprintf(
+		"https://github.com/golangci/golangci-lint/releases/download/v%s/%s.tar.gz",
+		version,
+		golangciLint,
+	)
+	if err := sgtool.FromRemote(
+		ctx,
+		binURL,
+		sgtool.WithDestinationDir(binDir),
+		sgtool.WithUntarGz(),
+		sgtool.WithRenameFile(fmt.Sprintf("%s/golangci-lint", golangciLint), name),
+		sgtool.WithSkipIfFileExists(binary),
+		sgtool.WithSymlink(binary),
+	); err != nil {
+		return fmt.Errorf("unable to download %s: %w", name, err)
+	}
+	configPath := defaultConfigPath()
+	err := CreateConfigFromTemplate(ctx, configPath, config)
+	if err != nil {
+		return fmt.Errorf("unable to create config file: %w", err)
+	}
+
+	return nil
+}
+
+func CreateConfigFromTemplate(ctx context.Context, outputPath string, config Config) error {
+	if config.RunRelativePathMode == "" {
+		config.RunRelativePathMode = RunRelativePathModeGitRoot
+		sg.Logger(ctx).Printf("Using default relative path mode: %s\n", config.RunRelativePathMode)
+	}
+	tmpl, err := template.New("golangci.yml").Parse(string(configTemplate))
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(outputPath), 0o755); err != nil {
+		return err
+	}
+	file, err := os.Create(outputPath)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	return tmpl.Execute(file, config)
+}


### PR DESCRIPTION
### Why?

Golangci-lint was bumped to v2.

### What?

- Add `sggolangcilintv2` as there are backwards braking changes to the CLI. The CLI arguments will differ from golangci-lint v1 and options around exclusion paths have been moved from the CLI so they must be defined in the config yaml.
- Deprecate `sggolangcilint`.
- Use golangci-lint v2.1.1.
- Run `golangci-lint migrate -c golangci.yml`. This sorted the linters for us, so they are now in alphabetical order. The `gci`, `gofumpt` linters were removed (now exists as formatters) and `gosimple` has been absorbed by `staticcheck`.
- Add comments back in which were removed by the migration tool.
- Address new linting issues found by golangci-lint.
- Use templating to allow per-project customization.

### Will be saved for a separate PR

- Formatting capabilities: https://github.com/einride/sage/pull/662
- Discussing adding/removing/reconfiguring [linters](https://golangci-lint.run/usage/linters/) - can be saved for backend guild session.

<details>
<summary>Enabled vs disabled linters</summary>

Name | Description | Enabled
-- | -- | -- 
asasalint | Check for pass []any as any in variadic func(...any). | ✅ 
asciicheck | Checks that all code identifiers does not have non-ASCII symbols in the name. | ✅ 
bidichk | Checks for dangerous unicode character sequences. | ✅ 
bodyclose | Checks whether HTTP response body is closed successfully. | ✅ 
canonicalheader | Canonicalheader checks whether net/http.Header uses canonical header. |  
containedctx | Containedctx is a linter that detects struct contained context.Context field. |   
contextcheck | Check whether the function uses a non-inherited context. |   
copyloopvar | A linter detects places where loop variables are copied. | ✅  
cyclop | Checks function and package cyclomatic complexity. |   
decorder | Check declaration order and count of types, constants, variables and functions. |   
depguard | Go linter that checks if package imports are in a list of acceptable packages. |   
dogsled | Checks assignments with too many blank identifiers (e.g. x, , , _, := f()). |   
dupl | Detects duplicate fragments of code. |   
dupword | Checks for duplicate words in the source code. |  
durationcheck | Check for two durations multiplied together. | ✅ 
err113 | Go linter to check the errors handling expressions. |  
errcheck | Check for unchecked errors. Unchecked errors can be critical bugs in some cases. |  ✅ 
errchkjson | Checks types passed to the json encoding functions. Reports unsupported types and reports occurrences where the check for the returned error can be omitted. | ✅
errname | Checks that sentinel errors are prefixed with the Err and error types are suffixed with the Error. | ✅ 
errorlint | Errorlint is a linter for that can be used to find code that will cause problems with the error wrapping scheme introduced in Go 1.13. | ✅ 
exhaustive | Check exhaustiveness of enum switch statements. |   
exhaustruct | Checks if all structure fields are initialized. |   
exptostd | Detects functions from golang.org/x/exp/ that can be replaced by std functions. | ✅ 
fatcontext | Detects nested contexts in loops and function literals. |  
forbidigo | Forbids identifiers. |   
forcetypeassert | Finds forced type assertions. |   
funlen | Checks for long functions. |   
ginkgolinter | Enforces standards of using ginkgo and gomega. | 
gocheckcompilerdirectives | Checks that go compiler directive comments (//go:) are valid. |   
gochecknoglobals | Check that no global variables exist. | ✅ 
gochecknoinits | Checks that no init functions are present in Go code. | ✅ 
gochecksumtype | Run exhaustiveness checks on Go "sum types". |   
gocognit | Computes and checks the cognitive complexity of functions. |   
goconst | Finds repeated strings that could be replaced by a constant. |   
gocritic | Provides diagnostics that check for bugs, performance and style issues.Extensible without recompilation through dynamic rules.Dynamic rules are written declaratively with AST patterns, filters, report message and optional suggestion. | ✅ 
gocyclo | Computes and checks the cyclomatic complexity of functions. |   
godot | Check if comments end in a period. | ✅ 
godox | Detects usage of FIXME, TODO and other keywords inside comments. |   
goheader | Checks if file header matches to pattern. |  
gomoddirectives | Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod. | ✅  
gomodguard | Allow and block list linter for direct Go module dependencies. This is different from depguard where there are different block types for example version constraints and module recommendations. | ✅ 
goprintffuncname | Checks that printf-like functions are named with f at the end. | ✅ 
gosec | Inspects source code for security problems. | ✅ 
gosmopolitan | Report certain i18n/l10n anti-patterns in your Go codebase. |   
govet | Report suspicious constructs, such as Printf calls whose arguments do not align with the format string. | ✅ 
grouper | Analyze expression groups. |   
iface | Detect the incorrect use of interfaces, helping developers avoid interface pollution. |  
importas | Enforces consistent import aliases. |  
inamedparam | Reports interfaces with unnamed method parameters. |   
ineffassign | Detect when assignments to existing variables are not used. | ✅ 
interfacebloat | A linter that checks the number of methods inside an interface. |   
intrange | Intrange is a linter to find places where for loops could make use of an integer range. |  
ireturn | Accept Interfaces, Return Concrete Types. |   
lll | Reports long lines. | ✅ 
loggercheck | Checks key value pairs for common logger libraries (kitlog,klog,logr,zap). |   
maintidx | Maintidx measures the maintainability index of each function. |   
makezero | Finds slice declarations with non-zero initial length. | ✅ 
mirror | Reports wrong mirror patterns of bytes/strings usage. |  
misspell | Finds commonly misspelled English words. | ✅ 
mnd | An analyzer to detect magic numbers. |   
musttag | Enforce field tags in (un)marshaled structs. |   
nakedret | Checks that functions with naked returns are not longer than a maximum size (can be zero). | ✅ 
nestif | Reports deeply nested if statements. |   
nilerr | Finds the code that returns nil even if it checks that the error is not nil. | ✅  
nilnesserr | Reports constructs that checks for err != nil, but returns a different nil value error.Powered by nilness and nilerr. |   
nilnil | Checks that there is no simultaneous return of nil error and an invalid value. |   
nlreturn | Nlreturn checks for a new line before return and branch statements to increase code clarity. |  
noctx | Finds sending http request without context.Context. | ✅ 
nolintlint | Reports ill-formed or insufficient nolint directives. | ✅ 
nonamedreturns | Reports all named returns. |   
nosprintfhostport | Checks for misuse of Sprintf to construct a host with port in a URL. |   
paralleltest | Detects missing usage of t.Parallel() method in your Go test. |   
perfsprint | Checks that fmt.Sprintf can be replaced with a faster alternative. |  
prealloc | Finds slice declarations that could potentially be pre-allocated. | ✅ 
predeclared | Find code that shadows one of Go's predeclared identifiers. | ✅ 
promlinter | Check Prometheus metrics naming via promlint. | ✅ 
protogetter | Reports direct reads from proto message fields when getters should be used. | ✅ 
reassign | Checks that package variables are not reassigned. |   
recvcheck | Checks for receiver type consistency. |   
revive | Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint. | ✅ 
rowserrcheck | Checks whether Rows.Err of rows is checked successfully. | ✅ 
sloglint | Ensure consistent code style when using log/slog. | ✅ 
spancheck | Checks for mistakes with OpenTelemetry/Census spans. | ✅ 
staticcheck | Go vet on steroids, applying a ton of static analysis checks. | ✅ 
sqlclosecheck | Checks that sql.Rows, sql.Stmt, sqlx.NamedStmt, pgx.Query are closed. | ✅ 
tagalign | Check that struct tags are well aligned. |  
tagliatelle | Checks the struct tags. |   
testableexamples | Linter checks if examples are testable (have an expected output). |   
testifylint | Checks usage of github.com/stretchr/testify. |  
testpackage | Linter that makes you use a separate _test package. |   
thelper | Thelper detects tests helpers which is not start with t.Helper() method. |   
tparallel | Tparallel detects inappropriate usage of t.Parallel() method in your Go test codes. | ✅ 
unconvert | Remove unnecessary type conversions. | ✅ 
unused | Check Go code for unused constants, variables, functions and types | ✅ 
unparam | Reports unused function parameters. |   
usestdlibvars | A linter that detect the possibility to use variables/constants from the Go standard library. | ✅ 
usetesting | Reports uses of functions with replacement inside the testing package. |  
varnamelen | Checks that the length of a variable's name matches its scope. |   
wastedassign | Finds wasted assignment statements. | ✅ 
whitespace | Whitespace is a linter that checks for unnecessary newlines at the start and end of functions, if, for, etc. | ✅ 
wrapcheck | Checks that errors returned from external packages are wrapped. |   
wsl | Add or remove empty lines. |
zerologlint | Detects the wrong usage of zerolog that a user forgets to dispatch with Send or Msg. |  



</details>


### Notes

- https://golangci-lint.run/product/migration-guide/
- https://golangci-lint.run/usage/formatters/
