### PR TITLE
feat(golangcilint): add formatting capabilities

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -14,7 +14,6 @@ import (
 	"go.einride.tech/sage/tools/sggo"
 	"go.einride.tech/sage/tools/sggolangcilint"
 	"go.einride.tech/sage/tools/sggolicenses"
-	"go.einride.tech/sage/tools/sggolines"
 	"go.einride.tech/sage/tools/sggopls"
 	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
@@ -30,7 +29,9 @@ func main() {
 }
 
 func Default(ctx context.Context) error {
-	sg.Deps(ctx, ConvcoCheck, GoLint, GoTest, FormatMarkdown, FormatYaml, BackstageValidate)
+	sg.Deps(ctx, ConvcoCheck, GoFormat, FormatMarkdown, FormatYaml, BackstageValidate)
+	sg.Deps(ctx, GoLint)
+	sg.SerialDeps(ctx, GoTest)
 	sg.SerialDeps(ctx, GoModTidy)
 	sg.SerialDeps(ctx, GoLicenses, GitVerifyNoDiff, GoPls)
 	return nil
@@ -66,8 +67,13 @@ func GoLintFix(ctx context.Context) error {
 }
 
 func GoFormat(ctx context.Context) error {
+	sg.Logger(ctx).Println("checking Go files for formatting...")
+	return sggolangcilint.Fmt(ctx)
+}
+
+func GoFormatFix(ctx context.Context) error {
 	sg.Logger(ctx).Println("formatting Go files...")
-	return sggolines.Run(ctx)
+	return sggolangcilint.FmtFix(ctx)
 }
 
 func GoLicenses(ctx context.Context) error {

--- a/Makefile
+++ b/Makefile
@@ -71,6 +71,10 @@ git-verify-no-diff: $(sagefile)
 go-format: $(sagefile)
 	@$(sagefile) GoFormat
 
+.PHONY: go-format-fix
+go-format-fix: $(sagefile)
+	@$(sagefile) GoFormatFix
+
 .PHONY: go-licenses
 go-licenses: $(sagefile)
 	@$(sagefile) GoLicenses

--- a/internal/codegen/imports.go
+++ b/internal/codegen/imports.go
@@ -99,6 +99,7 @@ func importPathToAssumedName(importPath string) string {
 	}
 	base = strings.TrimPrefix(base, "go-")
 	if i := strings.IndexFunc(base, func(r rune) bool {
+		//nolint:staticcheck // De Morgan's law intentionally not applied
 		return !('a' <= r && r <= 'z' || 'A' <= r && r <= 'Z' || '0' <= r && r <= '9' || r == '_' ||
 			r >= utf8.RuneSelf && (unicode.IsLetter(r) || unicode.IsDigit(r)))
 	}); i >= 0 {

--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -65,7 +65,11 @@ func generateMakefile(_ context.Context, g *codegen.File, pkg *doc.Package, mk M
 	g.P("export GOWORK ?= off")
 	g.P("ifndef go")
 	g.P("SAGE_GO_VERSION ?= ", defaultGoVersion)
-	g.P("export GOROOT := $(abspath $(cwd)/", filepath.Join(includePath, toolsDir, "go", "$(SAGE_GO_VERSION)", "go"), ")")
+	g.P(
+		"export GOROOT := $(abspath $(cwd)/",
+		filepath.Join(includePath, toolsDir, "go", "$(SAGE_GO_VERSION)", "go"),
+		")",
+	)
 	g.P("export PATH := $(PATH):$(GOROOT)/bin")
 	g.P("go := $(GOROOT)/bin/go")
 	g.P("os := $(shell uname | tr '[:upper:]' '[:lower:]')")

--- a/sgtool/file.go
+++ b/sgtool/file.go
@@ -341,7 +341,10 @@ func (s *fileState) extractTar(reader io.Reader) error {
 		//nolint:gosec // allow traversal into archive
 		path := filepath.Join(s.dstPath, dstName)
 		if strings.Contains(path, "..") {
-			return fmt.Errorf("encountered .. inside tar filepath (%s). For security reasons, this is not allowed", path)
+			return fmt.Errorf(
+				"encountered .. inside tar filepath (%s). For security reasons, this is not allowed",
+				path,
+			)
 		}
 
 		switch header.Typeflag {

--- a/tools/sgartifactregistry/auth.go
+++ b/tools/sgartifactregistry/auth.go
@@ -57,9 +57,9 @@ func NpmAuthenticate(ctx context.Context, packageJSONDir, registryURL string) er
 		yarnMajor = strings.Split(version, ".")[0]
 	}
 
-	switch {
+	switch yarnMajor {
 	// If yarn v1 or npm we use npm config
-	case yarnMajor == "1":
+	case "1":
 		cmd = sg.Command(
 			ctx,
 			"npm",

--- a/tools/sgcloudrun/config.go
+++ b/tools/sgcloudrun/config.go
@@ -388,7 +388,12 @@ func fetchImpersonatedAccessToken(ctx context.Context, serviceAccountEmail strin
 		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
 		serviceAccountEmail,
 	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serviceAccountImpersonationURL, bytes.NewReader(reqBody))
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		serviceAccountImpersonationURL,
+		bytes.NewReader(reqBody),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -263,3 +263,25 @@ linters:
       - third_party$
       - builtin$
       - examples$
+
+formatters:
+  enable:
+    - gci
+    - goimports
+    - gofumpt
+    - golines
+
+  settings:
+    gofumpt:
+      extra-rules: true
+    golines:
+      max-len: 120
+
+  exclusions:
+    generated: lax
+    paths:
+      - .git
+      - node_modules
+      - third_party$
+      - builtin$
+      - examples$

--- a/tools/sggolangcilint/golangci.yml
+++ b/tools/sggolangcilint/golangci.yml
@@ -1,20 +1,27 @@
+version: "2"
+
 run:
-  timeout: 10m
   build-tags:
     - wireinject
+  relative-path-mode: gomod
 
 issues:
   fix: false
-  exclude-dirs:
-    - .git
-    - node_modules
 
 linters:
-  disable-all: true
+  default: none
   enable:
+    # Check for pass []any as any in variadic func(...any).
+    # [fast: false, auto-fix: false]
+    - asasalint
+
     # Check that code does not contain non-ASCII identifiers.
     # [fast: true, auto-fix: false]
     - asciicheck
+
+    # Checks for dangerous unicode character sequences.
+    # [fast: true]
+    - bidichk
 
     # Check whether HTTP response body is closed successfully.
     # [fast: false, auto-fix: false]
@@ -32,6 +39,10 @@ linters:
     # [fast: false, auto-fix: false]
     - errcheck
 
+    # Checks types passed to the json encoding functions. Reports unsupported types and reports occurrences where the check for the returned error can be omitted.
+    # [fast: false, autofix: false]
+    - errchkjson
+
     # Check that sentinel errors are prefixed with the `Err` and error types are suffixed with the `Error`.
     # [fast: false, auto-fix: false]
     - errname
@@ -44,9 +55,9 @@ linters:
     # [fast: ?, auto-fix: true]
     - exptostd
 
-    # Check package import order and make it always deterministic.
-    # [fast: true, auto-fix: true]
-    - gci
+    # Check that no global variables exist.
+    # [fast: false, auto-fix: false]
+    - gochecknoglobals
 
     # Check that no init functions are present in Go code.
     # [fast: true, auto-fix: false]
@@ -60,10 +71,6 @@ linters:
     # [fast: true, auto-fix: true]
     - godot
 
-    # Check whether code was gofumpt-ed.
-    # [fast: true, auto-fix: true]
-    - gofumpt
-
     # Manage the use of 'replace', 'retract', and 'excludes' directives in go.mod.
     # [fast: true, auto-fix: false]
     - gomoddirectives
@@ -76,9 +83,9 @@ linters:
     # [fast: true, auto-fix: false]
     - goprintffuncname
 
-    # Check for code that can be simplified.
+    # Inspects source code for security problems.
     # [fast: false, auto-fix: false]
-    - gosimple
+    - gosec
 
     # Report suspicious constructs, such as Printf calls whose arguments do not align with the format string.
     # [fast: false, auto-fix: false]
@@ -108,6 +115,10 @@ linters:
     # [fast: false, auto-fix: false]
     - nilerr
 
+    # Finds sending http request without context.Context.
+    # [fast: false, auto-fix: false]
+    - noctx
+
     # Report ill-formed or insufficient nolint directives.
     # [fast: true, auto-fix: false]
     - nolintlint
@@ -128,9 +139,21 @@ linters:
     # [fast: false, auto-fix: true]
     - protogetter
 
+    # Fast, configurable, extensible, flexible, and beautiful linter for Go. Drop-in replacement of golint.
+    # [fast: false, auto-fix: true]
+    - revive
+
     # Check whether Err of rows is checked successfully.
     # [fast: false, auto-fix: false]
     - rowserrcheck
+
+    # Ensure consistent code style when using log/slog.
+    # [fast: false, auto-fix: false]
+    - sloglint
+
+    # Checks for mistakes with OpenTelemetry/Census spans.
+    # [fast: false, auto-fix: false]
+    - spancheck
 
     # Check that sql.Rows and sql.Stmt are closed.
     # [fast: false, auto-fix: false]
@@ -140,17 +163,9 @@ linters:
     # [fast: false, auto-fix: false]
     - staticcheck
 
-    # A replacement for golint.
-    # [fast: false, auto-fix: false]
-    - stylecheck
-
     # Detect inappropriate usage of t.Parallel() method in your Go test codes.
     # [fast: false, auto-fix: false]
     - tparallel
-
-    # Parses and type-checks Go code.
-    # [fast: false, auto-fix: false]
-    - typecheck
 
     # Remove unnecessary type conversions.
     # [fast: false, auto-fix: false]
@@ -160,6 +175,10 @@ linters:
     # [fast: false, auto-fix: false]
     - unused
 
+    # A linter that detect the possibility to use variables/constants from the Go standard library.
+    # [fast: true, auto-fix: true]
+    - usestdlibvars
+
     # Find wasted assignment statements.
     # [fast: false, auto-fix: false]
     - wastedassign
@@ -167,113 +186,80 @@ linters:
     # Detect leading and trailing whitespace.
     # [fast: true, auto-fix: true]
     - whitespace
+  settings:
+    errorlint:
+      errorf: false
 
-    # Check that no global variables exist.
-    # [fast: true, auto-fix: false]
-    - gochecknoglobals
+    gomoddirectives:
+      replace-local: true
 
-    # Inspect source code for security problems.
-    # [fast: false, auto-fix: false]
-    - gosec
+    gomodguard:
+      blocked:
+        modules:
+          - github.com/sirupsen/logrus:
+              recommendations:
+                - go.uber.org/zap
+              reason: Use Zap for logging.
+          - github.com/rs/zerolog:
+              recommendations:
+                - go.uber.org/zap
+              reason: Use Zap for logging.
+          - github.com/pkg/errors:
+              recommendations:
+                - errors
+                - fmt
+              reason: Use the standard library error packages.
+          - golang.org/x/xerrors:
+              recommendations:
+                - errors
+                - fmt
+              reason: Use the standard library error packages.
+          - github.com/golang/protobuf:
+              recommendations:
+                - google.golang.org/protobuf
+              reason: The protobuf v1 module is deprecated.
+          - github.com/stretchr/testify:
+              recommendations:
+                - gotest.tools/v3
+              reason: More reliably supports protobuf messages.
 
-    # Find sending http request without context.Context.
-    # [fast: false, auto-fix: false]
-    - noctx
+    gosec:
+      excludes:
+        - G115
 
-    # Drop-in replacement of golint.
-    # [fast: false, auto-fix: false]
-    - revive
+    lll:
+      line-length: 120
+      tab-width: 1
 
-    # Check for pass []any as any in variadic func(...any).
-    # [fast: false, auto-fix: false]
-    - asasalint
+    misspell:
+      locale: US
+      ignore-rules:
+        - cancelled
+        - cancelling
+        - analyses
 
-    # Check for dangerous unicode character sequences.
-    # [fast: true, auto-fix: false]
-    - bidichk
+    prealloc:
+      simple: true
+      range-loops: true
+      for-loops: true
 
-    # Check types passed to the json encoding functions.
-    # [fast: false, auto-fix: false]
-    - errchkjson
+    protogetter:
+      skip-any-generated: true
 
-    # Check for the possibility to use variables/constants from the Go standard library.
-    # [fast: true, auto-fix: false]
-    - usestdlibvars
+    staticcheck:
+      checks:
+        - all
 
-    # Checks for mistakes with OpenTelemetry/Census spans.
-    # [fast: false, auto-fix: false]
-    - spancheck
-
-    # Ensure consistent code style when using log/slog.
-    - sloglint
-linters-settings:
-  gomodguard:
-    blocked:
-      modules:
-        - github.com/sirupsen/logrus:
-            recommendations:
-              - go.uber.org/zap
-            reason: "Use Zap for logging."
-        - github.com/rs/zerolog:
-            recommendations:
-              - go.uber.org/zap
-            reason: "Use Zap for logging."
-        - github.com/pkg/errors:
-            recommendations:
-              - errors
-              - fmt
-            reason: "Use the standard library error packages."
-        - golang.org/x/xerrors:
-            recommendations:
-              - errors
-              - fmt
-            reason: "Use the standard library error packages."
-        - github.com/golang/protobuf:
-            recommendations:
-              - google.golang.org/protobuf
-            reason: "The protobuf v1 module is deprecated."
-        - github.com/stretchr/testify:
-            recommendations:
-              - gotest.tools/v3
-            reason: "More reliably supports protobuf messages."
-
-  gofumpt:
-    extra-rules: true
-
-  gosec:
-    excludes:
-      # Flags for potentially-unsafe casting of ints. Prone to lots of false positives.
-      - G115
-
-  lll:
-    line-length: 120
-    tab-width: 1
-
-  misspell:
-    locale: US
-    ignore-words:
-      - cancelled
-      - cancelling
-      - analyses # allow analyses as a plural form of analysis
-
-  prealloc:
-    simple: true
-    range-loops: true
-    for-loops: true
-
-  protogetter:
-    skip-any-generated: true
-
-  staticcheck:
-    checks: [all]
-
-  stylecheck:
-    checks: [all]
-
-  errorlint:
-    # Don't enforce %w to minimize implicit interface leakage.
-    # https://github.com/dwmkerr/hacker-laws#hyrums-law-the-law-of-implicit-interfaces
-    errorf: false
-
-  gomoddirectives:
-    replace-local: true
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - .git
+      - node_modules
+      - third_party$
+      - builtin$
+      - examples$

--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -17,7 +17,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "1.64.8"
+	version = "2.0.1"
 )
 
 //go:embed golangci.yml
@@ -37,12 +37,8 @@ func CommandInDirectory(ctx context.Context, directory string, args ...string) *
 	if _, err := os.Lstat(configPath); errors.Is(err, os.ErrNotExist) {
 		configPath = defaultConfigPath()
 	}
-	var excludeArg []string
-	if directory == sg.FromSageDir() {
-		excludeArg = append(excludeArg, "--exclude", "(is a global variable|is unused)")
-	}
 	cmdArgs := append([]string{"run", "--allow-parallel-runners", "-c", configPath}, args...)
-	cmd := Command(ctx, append(cmdArgs, excludeArg...)...)
+	cmd := Command(ctx, cmdArgs...)
 	cmd.Dir = directory
 	return cmd
 }


### PR DESCRIPTION
### Why?

- `golangci-lint fmt` is a new command in golangci-lint v2.

### What?

- Add the formatters section to the config.
- Add new `sggolangcilint.Fmt` and `sggolangcilint.FmtFix` functions.
- Call `sggolangcilint.Fmt` instead of `sggolines.Format` from `main.go`.
- Run `make go-format-fix` to fix the files which are in need of formatting.

### Notes

- Builds upon #661 
- The only difference between `Fmt` and `FmtFix` is that the `--diff` argument is passed into the former. I think, however, it is clearer to provide these two explicit functions. But if you disagree, we can just call the `Fmt` function with a `--diff` argument for checking and omitting it for writing.