### PR TITLE
feat: add `go-version-file` to sage composite action

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -17,6 +17,10 @@ inputs:
     required: false
     default: '1.24'
 
+  go-version-file:
+    description: 'Path to the go.mod or go.work file.'
+    required: false
+
   check-latest:
     description: If true, checks whether the cached go version is the latest, if not then downloads the latest. Useful when you need to use the latest version.
     required: false
@@ -42,9 +46,18 @@ runs:
         submodules: ${{ inputs.checkout-submodules }}
 
     - name: Set up Go
+      if: ${{ inputs.go-version-file == '' }}
       uses: actions/setup-go@v5
       with:
         go-version: ${{ inputs.go-version }}
+        check-latest: ${{ inputs.check-latest }}
+        cache: false # cache is handled by separate actions/cache step, see https://github.com/actions/setup-go/issues/358
+
+    - name: Set up Go using go version file
+      if: ${{ inputs.go-version-file != '' }}
+      uses: actions/setup-go@v5
+      with:
+        go-version-file: ${{ inputs.go-version-file }}
         check-latest: ${{ inputs.check-latest }}
         cache: false # cache is handled by separate actions/cache step, see https://github.com/actions/setup-go/issues/358
 


### PR DESCRIPTION
### Why this change?

The Sage action today forces you to specify a specific Go version for your project. Would be nice if it would be able to read it from the `go.mod` instead.

Example, how it works today:

```yml
    steps:
      - name: Setup Sage
        uses: einride/sage/actions/setup@master
        with:
          go-version: '1.24'
```

How it could work:


```yml
    steps:
      - name: Setup Sage
        uses: einride/sage/actions/setup@master
        with:
          go-version-file: go.mod
```


### What was changed?

- Add new action input `go-version-file` and pass it into the `go-version-file` of `actions/setup-go@v5`.

### Notes

- Unfortunately, the `go-version` input has a default value, which is why I had to duplicate the `actions/setup-go@v5` step and add an if-condition to both of them. If you pass both a `go-version` and `go-version-file` value to `actions/setup-go@v5`, it will take the `go-version` value.
- `actions/setup-go` docs: [Getting go version from the go.mod file](https://github.com/actions/setup-go#getting-go-version-from-the-gomod-file)
- `actions/setup-go`'s `go-version-file` input and description: https://github.com/actions/setup-go/blob/main/action.yml#L7
- Is it backwards compatible? Yes, it is, you can choose whichever field you want to use to specify the Go version.