### PR TITLE
fix: remove deprecated -d flag from go get

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,7 @@ sage:
 
 .PHONY: update-sage
 update-sage: $(go)
-	@cd .sage && $(go) get -d go.einride.tech/sage@latest && $(go) mod tidy && $(go) run .
+	@cd .sage && $(go) get go.einride.tech/sage@latest && $(go) mod tidy && $(go) run .
 
 .PHONY: clean-sage
 clean-sage:

--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -91,7 +91,7 @@ func generateMakefile(_ context.Context, g *codegen.File, pkg *doc.Package, mk M
 	g.P()
 	g.P(".PHONY: update-sage")
 	g.P("update-sage: $(go)")
-	g.P("\t@cd ", includePath, " && $(go) get -d go.einride.tech/sage@latest && $(go) mod tidy && $(go) run .")
+	g.P("\t@cd ", includePath, " && $(go) get go.einride.tech/sage@latest && $(go) mod tidy && $(go) run .")
 	g.P()
 	g.P(".PHONY: clean-sage")
 	g.P("clean-sage:")


### PR DESCRIPTION
As of Go 1.18 the -d flag for go get is deprecated and go get will always act as if the -d flag were enabled.


(#666 😈 )