### PR TITLE
feat(poetry): bump to latest version

### DIFF
--- a/tools/sgpoetry/command.go
+++ b/tools/sgpoetry/command.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "poetry"
-	version = "1.8.3"
+	version = "2.1.2"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
### Why?

The Poetry version used by sage is about a year old. Dependabot is using v2.x and it's likely a good idea to be on the same major version. 


### What?

- Change Sage's poetry version from v1.8.3 to v2.1.2.

### Notes

- Dependabot is using v2.1.1 but I don't think that should matter.