### PR TITLE
feat(sggolangcilintv2): add formatting

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -14,7 +14,6 @@ import (
 	"go.einride.tech/sage/tools/sggo"
 	"go.einride.tech/sage/tools/sggolangcilintv2"
 	"go.einride.tech/sage/tools/sggolicenses"
-	"go.einride.tech/sage/tools/sggolines"
 	"go.einride.tech/sage/tools/sggopls"
 	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
@@ -73,7 +72,10 @@ func GoLintFix(ctx context.Context) error {
 
 func GoFormat(ctx context.Context) error {
 	sg.Logger(ctx).Println("formatting Go files...")
-	return sggolines.Run(ctx)
+	return sggolangcilintv2.Fmt(
+		ctx,
+		sggolangcilintv2.Config{RunRelativePathMode: sggolangcilintv2.RunRelativePathModeGitRoot},
+	)
 }
 
 func GoLicenses(ctx context.Context) error {

--- a/tools/sggolangcilintv2/golangci.yml.tmpl
+++ b/tools/sggolangcilintv2/golangci.yml.tmpl
@@ -261,3 +261,23 @@ linters:
     paths:{{ range .LintersExclusionsPaths }}
       - {{ . }}{{ end }}
     {{- end }}
+
+  formatters:
+    enable:
+    - gci
+    - goimports
+    - gofumpt
+    - golines
+
+    settings:
+    gofumpt:
+      extra-rules: true
+    golines:
+      max-len: 120
+
+    exclusions:
+    generated: lax
+    {{- if .FormattersExclusionsPaths }}
+    paths:{{ range .FormattersExclusionsPaths }}
+      - {{ . }}{{ end }}
+    {{- end }}

--- a/tools/sggolangcilintv2/tools.go
+++ b/tools/sggolangcilintv2/tools.go
@@ -43,6 +43,12 @@ type Config struct {
 	// - allow you to optionally use regexps here, like ".*\\.my\\.go$".
 	// - treat paths relative to the setting of RunRelativePathMode.
 	LintersExclusionsPaths []string
+	// Which file paths to exclude from issue reporting. The paths will still be analyzed.
+	// Golangci-Lint will:
+	// - replace "/" with the current OS file path separator to properly work on Windows.
+	// - allow you to optionally use regexps here, like ".*\\.my\\.go$".
+	// - treat paths relative to the setting of RunRelativePathMode.
+	FormattersExclusionsPaths []string
 }
 
 func Command(ctx context.Context, config Config, args ...string) *exec.Cmd {


### PR DESCRIPTION
### Why?

Golangci-lint v2 offers Go file formatting (docs/details on this [here](https://golangci-lint.run/usage/formatters/)), which is nice, as we don't have to chain the different formatters manually, or for example run only `golines` as formatter (which was the case in this repo). This can instead be delegated to golangci-lint and configured in the config yaml.

I think that this could nicely formalize how we expect formatting in CI.

### What?

- add formatters to config file template along with "sane and default" config values
- add functions for formatting; `sggolangcilintv2.Fmt` which writes the files.
- replace golines as formatter with `sggolangcilintv2.Fmt` here in the sage repo.

### Notes

- This PR supersedes https://github.com/einride/sage/pull/662
- Add argument `--diff` if you want `sggolangcilintv2.Fmt` to not write the files and return a non-zero status code when formatting is needed.
