### PR TITLE
feat(sggolangcilint): add support for empty go.mod files

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -57,6 +57,14 @@ func Run(ctx context.Context, args ...string) error {
 		if d.IsDir() || d.Name() != "go.mod" {
 			return nil
 		}
+		fileInfo, err := d.Info()
+		if err != nil {
+			return err
+		}
+		// ignore if it's an empty go.mod
+		if fileInfo.Size() == 0 {
+			return nil
+		}
 		cmd := CommandInDirectory(ctx, filepath.Dir(path), args...)
 		commands = append(commands, cmd)
 		return cmd.Start()

--- a/tools/sggolangcilintv2/tools.go
+++ b/tools/sggolangcilintv2/tools.go
@@ -106,6 +106,14 @@ func Fix(ctx context.Context, config Config, args ...string) error {
 		if d.IsDir() || d.Name() != "go.mod" {
 			return nil
 		}
+		fileInfo, err := d.Info()
+		if err != nil {
+			return err
+		}
+		// ignore if it's an empty go.mod
+		if fileInfo.Size() == 0 {
+			return nil
+		}
 		cmd := Command(
 			ctx,
 			config,


### PR DESCRIPTION
according to docs https://go.dev/ref/mod#vcs-dir

```For example, if a repository has large files checked into a testdata directory,
the module author could add an empty go.mod file in testdata so their users don’t
need to download those files.
```

This adds support for sggolangcilint module to ignore folders containing empty go.mod files.