### PR TITLE
ci: allow running release workflow on-demand

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   push:
     branches: [master]
 


### PR DESCRIPTION
For some reason, the latest commit did not run in CI on master. This has also happened in the past several times. I really don't see why this is ...

Can we add a manual trigger, so that we can trigger a release when this happens?
Until, of course, someone figures out the root cause.