### PR TITLE
perf(ci/setup-sage): include golangci-lint cache in sage cache

### DIFF
--- a/actions/setup/action.yml
+++ b/actions/setup/action.yml
@@ -78,6 +78,7 @@ runs:
           ./.sage/tools
           ./.sage/bin
           /home/runner/.cache/go-build
+          /home/runner/.cache/golangci-lint
           /home/runner/go/pkg/mod
           /home/runner/go/bin
           /home/runner/.ko/cache


### PR DESCRIPTION
In one of our repos this made the time linting go down from about `1min` to `4s`.