### PR TITLE
feat(sggolangcilintv2): log which folder is being linted

### DIFF
--- a/tools/sggolangcilintv2/tools.go
+++ b/tools/sggolangcilintv2/tools.go
@@ -70,6 +70,7 @@ func CommandInDirectory(ctx context.Context, config Config, directory string, ar
 	cmdArgs := append([]string{"run", "--allow-parallel-runners", "-c", configPath}, args...)
 	cmd := Command(ctx, config, cmdArgs...)
 	cmd.Dir = directory
+	sg.Logger(ctx).Printf("Running golangci-lint in : %s\n", directory)
 	return cmd
 }
 


### PR DESCRIPTION
### Why?

I noticed that when calling `sggolangcilintv2.Run()` (executed from the git root), golangci-lint would start linting other `.sage` folders deeply nested in my project. This never happens in CI, but it happens sometimes locally. 

This was difficult to catch from the log output.

### What?

- Add log around the folder golangci-lint will execute in.

### Notes

We can pass in exclusion rules for the `golangci.yml` generation, but this does not control in which folders golangci-lint gets executed. I started dabbling with automatically ignoring other `.sage` folders [here](https://github.com/einride/sage/blob/ec6f97543c63eded51d43fd7f5ffa55e724a9ee7/tools/sggolangcilintv2/tools.go#L251), but eventually threw that away as I think the config became too complex and started assuming things about the user's setup. I'm now instead explicitly linting the folders I want linted in my projects:

```go
func GoLint(ctx context.Context) error {
    // Lint the backend folder
	if err := sggolangcilintv2.CommandInDirectory(
		ctx, sggolangcilintv2.Config{}, sg.FromGitRoot("backend"),
	).Run(); err != nil {
		return err
	}
    // Lint some parts of the .sage folder
	return sggolangcilintv2.CommandInDirectory(ctx, sggolangcilintv2.Config{
		LintersExclusionsPaths: []string{"bin", "build", "tools"},
	}, sg.FromGitRoot(".sage")).Run()
}
```
