### PR TITLE
Fix wrong yaml indentation

### DIFF
--- a/sg/makefile.go
+++ b/sg/makefile.go
@@ -65,7 +65,11 @@ func generateMakefile(_ context.Context, g *codegen.File, pkg *doc.Package, mk M
 	g.P("export GOWORK ?= off")
 	g.P("ifndef go")
 	g.P("SAGE_GO_VERSION ?= ", defaultGoVersion)
-	g.P("export GOROOT := $(abspath $(cwd)/", filepath.Join(includePath, toolsDir, "go", "$(SAGE_GO_VERSION)", "go"), ")")
+	g.P(
+		"export GOROOT := $(abspath $(cwd)/",
+		filepath.Join(includePath, toolsDir, "go", "$(SAGE_GO_VERSION)", "go"),
+		")",
+	)
 	g.P("export PATH := $(PATH):$(GOROOT)/bin")
 	g.P("go := $(GOROOT)/bin/go")
 	g.P("os := $(shell uname | tr '[:upper:]' '[:lower:]')")

--- a/sgtool/file.go
+++ b/sgtool/file.go
@@ -341,7 +341,10 @@ func (s *fileState) extractTar(reader io.Reader) error {
 		//nolint:gosec // allow traversal into archive
 		path := filepath.Join(s.dstPath, dstName)
 		if strings.Contains(path, "..") {
-			return fmt.Errorf("encountered .. inside tar filepath (%s). For security reasons, this is not allowed", path)
+			return fmt.Errorf(
+				"encountered .. inside tar filepath (%s). For security reasons, this is not allowed",
+				path,
+			)
 		}
 
 		switch header.Typeflag {

--- a/tools/sgcloudrun/config.go
+++ b/tools/sgcloudrun/config.go
@@ -388,7 +388,12 @@ func fetchImpersonatedAccessToken(ctx context.Context, serviceAccountEmail strin
 		"https://iamcredentials.googleapis.com/v1/projects/-/serviceAccounts/%s:generateAccessToken",
 		serviceAccountEmail,
 	)
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, serviceAccountImpersonationURL, bytes.NewReader(reqBody))
+	req, err := http.NewRequestWithContext(
+		ctx,
+		http.MethodPost,
+		serviceAccountImpersonationURL,
+		bytes.NewReader(reqBody),
+	)
 	if err != nil {
 		return "", err
 	}

--- a/tools/sggolangcilintv2/golangci.yml.tmpl
+++ b/tools/sggolangcilintv2/golangci.yml.tmpl
@@ -262,20 +262,20 @@ linters:
       - {{ . }}{{ end }}
     {{- end }}
 
-  formatters:
-    enable:
+formatters:
+  enable:
     - gci
     - goimports
     - gofumpt
     - golines
 
-    settings:
+  settings:
     gofumpt:
       extra-rules: true
     golines:
       max-len: 120
 
-    exclusions:
+  exclusions:
     generated: lax
     {{- if .FormattersExclusionsPaths }}
     paths:{{ range .FormattersExclusionsPaths }}


### PR DESCRIPTION
### Why?

Formatting does not currently work, when running `sggolangcilintv2.Fmt` due to wrong indentations in the yaml template.

### What?

- Fix indentation in config file.
- Also fix formatting issues that are now surfacing, as we are linting/formatting this repo properly.
