### PR TITLE
feat(sgprotocgengoaiptest): bump to v0.32.0

### DIFF
--- a/tools/sgprotocgengoaiptest/tools.go
+++ b/tools/sgprotocgengoaiptest/tools.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	version = "0.31.0"
+	version = "0.32.0"
 	name    = "protoc-gen-go-aip-test"
 )
 


### PR DESCRIPTION
https://github.com/einride/protoc-gen-go-aip-test/releases/tag/v0.32.0

This is related to this change https://github.com/einride/aip-go/pull/348