### PR TITLE
ci(sage): use newer terraform summary

### DIFF
--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -29,7 +29,7 @@ func Command(ctx context.Context, args ...string) *exec.Cmd {
 	return sg.Command(ctx, sg.FromBinDir(binaryName), args...)
 }
 
-func CommentOnPullRequestWithPlan(ctx context.Context, prNumber, environment, planFilePath string) *exec.Cmd {
+func CommentOnPRWithPlanSummarized(ctx context.Context, prNumber, environment, planFilePath string) *exec.Cmd {
 	cmd := Command(
 		ctx,
 		"show",


### PR DESCRIPTION
## Update tf summary message
### Why?
- We are using the older `CommentOnPullRequestWithPlan` which does not have colorful emojis etc.
### What?
- Update to the newer `CommentOnPRWithPlanSummarized`.
### Notes
- This PR was generated with [multipr](https://github.com/fredrikaverpil/multipr)

```yml
search:
  github:
    method: code
    query: --owner einride CommentOnPullRequestWithPlan
identify:
  - name: Find old function
    cmd: |
      rg --hidden 'CommentOnPullRequestWithPlan'
changes:
  - name: Update function
    cmd: rg -l --hidden 'CommentOnPullRequestWithPlan' | xargs sed -i 's/CommentOnPullRequestWithPlan/CommentOnPRWithPlanSummarized/g'
pr:
  github:
    branch: chore/better-tf-summary
    title: "ci(sage): use newer terraform summary"
    body: |
      ## Update tf summary message
      ### Why?
      - We are using the older `CommentOnPullRequestWithPlan` which does not have colorful emojis etc.
      ### What?
      - Update to the newer `CommentOnPRWithPlanSummarized`.
      ### Notes
      - This PR was generated with [multipr](https://github.com/fredrikaverpil/multipr)
```
