### PR TITLE
chore(sgcloudendpoints): Upgrade ESP version to 2.53

### DIFF
--- a/tools/sgcloudendpoints/tools.go
+++ b/tools/sgcloudendpoints/tools.go
@@ -18,7 +18,7 @@ import (
 )
 
 // espVersion is the version of ESPv2 used for building images.
-const espVersion = "2.52.0"
+const espVersion = "2.53.0"
 
 //go:embed Dockerfile
 var dockerfile []byte


### PR DESCRIPTION
This will bump Alpine version from 2.18 to 2.20 (GoogleCloudPlatform/esp-v2#960) and thus fix a bunch of underlying OS vulnerabilities.