### PR TITLE
feat(sgterraform): change comment summary to use "destroy" and "add" instead of replace

### DIFF
--- a/tools/sgterraform/tools.go
+++ b/tools/sgterraform/tools.go
@@ -185,7 +185,6 @@ func getCommentSummary(ctx context.Context, planFilePath string) (statusIcon, su
 	create := TfChange{actionName: "Create", changes: make(map[string]int), actionCount: 0}
 	destroy := TfChange{actionName: "Destroy", changes: make(map[string]int), actionCount: 0}
 	update := TfChange{actionName: "Update", changes: make(map[string]int), actionCount: 0}
-	replace := TfChange{actionName: "Replace", changes: make(map[string]int), actionCount: 0}
 	forget := TfChange{actionName: "Forget", changes: make(map[string]int), actionCount: 0}
 	for _, res := range jsonPlan.ResourceChanges {
 		actions := res.Change.Actions
@@ -198,7 +197,8 @@ func getCommentSummary(ctx context.Context, planFilePath string) (statusIcon, su
 		case actions.Update():
 			update.add(resourceType)
 		case actions.Replace():
-			replace.add(resourceType)
+			create.add(resourceType)
+			destroy.add(resourceType)
 		case actions.Forget():
 			forget.add(resourceType)
 		case
@@ -217,21 +217,20 @@ func getCommentSummary(ctx context.Context, planFilePath string) (statusIcon, su
 	if update.actionCount > 0 {
 		statusIcon = ":orange_circle:"
 	}
-	if destroy.actionCount > 0 || replace.actionCount > 0 {
+	if destroy.actionCount > 0 {
 		statusIcon = ":red_circle:"
 	}
 
 	summary = fmt.Sprintf(`
-Plan Summary: %d to create, %d to update, %d to replace, %d to destroy, %d to forget.
+Plan Summary: %d to create, %d to update, %d to destroy, %d to forget.
 <br/>
 %s
 `,
 		create.actionCount,
 		update.actionCount,
-		replace.actionCount,
 		destroy.actionCount,
 		forget.actionCount,
-		mapToHTMLList([]TfChange{create, destroy, update, replace}),
+		mapToHTMLList([]TfChange{create, destroy, update}),
 	)
 
 	return statusIcon, summary


### PR DESCRIPTION
We have previously used "Replace" to try and make it clear that a
resource was being replaced rather than just being destroyed and/or
added however that can be a little confusing as Terraform itself does
not use any such concept in their plans and it runs the risk of
someone missing the fact that a resource is being destroyed.

So in this commit we instead add the resource to the list of resources
being added and created when a resource is being "replaced".
