### PR TITLE
fix: bump golangci-lint to 2.4.0 to support go1.25 and fix lint issues

### DIFF
--- a/sg/path.go
+++ b/sg/path.go
@@ -2,6 +2,7 @@ package sg
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -28,7 +29,9 @@ func FromGitRoot(pathElems ...string) string {
 	// We use exec.Command here because this command runs in a global,
 	// which is set up before logging is configured, resulting in unwanted log prints.
 	var output bytes.Buffer
-	c := exec.Command("git", []string{"rev-parse", "--show-toplevel"}...)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	c := exec.CommandContext(ctx, "git", []string{"rev-parse", "--show-toplevel"}...)
 	c.Env = os.Environ()
 	c.Stderr = os.Stderr
 	c.Stdout = &output

--- a/tools/sgcloudspanner/emulator.go
+++ b/tools/sgcloudspanner/emulator.go
@@ -108,8 +108,9 @@ func inspectPortAddress(ctx context.Context, containerID, containerPort string) 
 
 func awaitReachable(ctx context.Context, addr string, wait, maxWait time.Duration) error {
 	deadline := time.Now().Add(maxWait)
+	dialer := net.Dialer{Deadline: deadline}
 	for time.Now().Before(deadline) {
-		if c, err := net.Dial("tcp", addr); err == nil {
+		if c, err := dialer.DialContext(ctx, "tcp", addr); err == nil {
 			_ = c.Close()
 			return nil
 		}

--- a/tools/sggolangcilintv2/tools.go
+++ b/tools/sggolangcilintv2/tools.go
@@ -20,7 +20,7 @@ import (
 
 const (
 	name    = "golangci-lint"
-	version = "2.1.5"
+	version = "2.4.0"
 
 	RunRelativePathModeGitRoot    = "gitroot"
 	RunRelativePathModeGomod      = "gomod"

--- a/tools/sgpostgres/local.go
+++ b/tools/sgpostgres/local.go
@@ -145,8 +145,9 @@ func inspectPortAddress(ctx context.Context, containerID, containerPort string) 
 
 func awaitReachable(ctx context.Context, addr string, wait, maxWait time.Duration) error {
 	deadline := time.Now().Add(maxWait)
+	dialer := net.Dialer{Deadline: deadline}
 	for time.Now().Before(deadline) {
-		if c, err := net.Dial("tcp", addr); err == nil {
+		if c, err := dialer.DialContext(ctx, "tcp", addr); err == nil {
 			_ = c.Close()
 			return nil
 		}


### PR DESCRIPTION
https://golangci-lint.run/docs/product/changelog/#v240