### PR TITLE
Handles empty go.mod in sggolangcilintv2.Run

### DIFF
--- a/tools/sggolangcilintv2/tools.go
+++ b/tools/sggolangcilintv2/tools.go
@@ -94,6 +94,14 @@ func Run(ctx context.Context, config Config, args ...string) error {
 		if d.IsDir() || d.Name() != "go.mod" {
 			return nil
 		}
+		fileInfo, err := d.Info()
+		if err != nil {
+			return err
+		}
+		// ignore if it's an empty go.mod
+		if fileInfo.Size() == 0 {
+			return filepath.SkipAll
+		}
 		cmd := CommandRunInDirectory(ctx, config, filepath.Dir(path), args...)
 		commands = append(commands, cmd)
 		return cmd.Start()


### PR DESCRIPTION
tried migrating a project to sggolangcilintv2 and got an error about handling empty go.mod files