### PR TITLE
feat(sgconvco): bump to v0.6.2

### DIFF
--- a/tools/sgconvco/tools.go
+++ b/tools/sgconvco/tools.go
@@ -15,7 +15,7 @@ import (
 
 const (
 	name    = "convco"
-	version = "0.6.1"
+	version = "0.6.2"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
Had a problem where the download of v0.6.1 would not work... but it works now. But I already prepared this so, yeah, maybe let's merge it in. 😆 