### PR TITLE
fix(sggopls): bump version to avoid CI breaking

### DIFF
--- a/tools/sggopls/tools.go
+++ b/tools/sggopls/tools.go
@@ -10,7 +10,7 @@ import (
 
 const (
 	name    = "gopls"
-	version = "v0.18.0"
+	version = "v0.20.0"
 )
 
 // Check runs `gopls check <PATH1> <PATH2>`.


### PR DESCRIPTION
Since we use `check-latest: true` in the composite action which sets up Go, we get new Go minor versions automatically. Apparently, this current one requires a newer gopls version.

@joaoeinride maybe we should just disable the [gopls job](https://github.com/einride/sage/actions/runs/18540824586/job/52847563861?pr=711) for now, I'm not sure who actually makes use of it?