### PR TITLE
ci: remove gopls from ci

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -18,18 +18,3 @@ jobs:
 
       - name: Make
         run: make
-
-  gopls:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-
-      - name: Setup Sage
-        uses: ./actions/setup
-        with:
-          go-version: "stable"
-
-      - name: Make
-        run: make go-pls
-

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -2,10 +2,6 @@ package main
 
 import (
 	"context"
-	"fmt"
-	"io/fs"
-	"path/filepath"
-	"strings"
 
 	"go.einride.tech/sage/sg"
 	"go.einride.tech/sage/tools/sgbackstage"
@@ -14,7 +10,6 @@ import (
 	"go.einride.tech/sage/tools/sggo"
 	"go.einride.tech/sage/tools/sggolangcilintv2"
 	"go.einride.tech/sage/tools/sggolicenses"
-	"go.einride.tech/sage/tools/sggopls"
 	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
 )
@@ -51,15 +46,6 @@ func GoLint(ctx context.Context) error {
 		ctx,
 		sggolangcilintv2.Config{RunRelativePathMode: sggolangcilintv2.RunRelativePathModeGitRoot},
 	)
-}
-
-func GoPls(ctx context.Context) error {
-	sg.Logger(ctx).Println("Linting Go files with gopls...")
-	filePaths, err := goFilePaths()
-	if err != nil {
-		return err
-	}
-	return sggopls.Check(ctx, filePaths).Run()
 }
 
 func GoLintFix(ctx context.Context) error {
@@ -106,25 +92,4 @@ func BackstageValidate(ctx context.Context) error {
 func GitVerifyNoDiff(ctx context.Context) error {
 	sg.Logger(ctx).Println("verifying that git has no diff...")
 	return sggit.VerifyNoDiff(ctx)
-}
-
-func goFilePaths() ([]string, error) {
-	var goFilePaths []string
-	err := filepath.WalkDir(sg.FromGitRoot(), func(path string, d fs.DirEntry, err error) error {
-		if err != nil {
-			return err
-		}
-		if d.IsDir() {
-			return nil
-		}
-		if !strings.HasSuffix(path, ".go") {
-			return nil
-		}
-		goFilePaths = append(goFilePaths, path)
-		return nil
-	})
-	if err != nil {
-		return nil, fmt.Errorf("gathering list of go files: %w", err)
-	}
-	return goFilePaths, nil
 }

--- a/Makefile
+++ b/Makefile
@@ -87,10 +87,6 @@ go-lint-fix: $(sagefile)
 go-mod-tidy: $(sagefile)
 	@$(sagefile) GoModTidy
 
-.PHONY: go-pls
-go-pls: $(sagefile)
-	@$(sagefile) GoPls
-
 .PHONY: go-test
 go-test: $(sagefile)
 	@$(sagefile) GoTest


### PR DESCRIPTION
We don't really use this CI workflow for anything. Recently, it started
failing and was fixed in https://github.com/einride/sage/pull/711

To avoid unnecessary noise and maintenance, I'm removing it from CI
here.
