### PR TITLE
feat(sgbuf): bump buf

### DIFF
--- a/tools/sgbuf/tools.go
+++ b/tools/sgbuf/tools.go
@@ -14,7 +14,7 @@ import (
 )
 
 const (
-	version = "1.57.2"
+	version = "1.59.0"
 	name    = "buf"
 )
 


### PR DESCRIPTION
This release takes the LSP out of beta and adds functionality to the LSP.

> Promote `buf beta lsp` to `buf lsp serve`. Command `buf beta lsp` is
now deprecated.

https://github.com/bufbuild/buf/releases/tag/v1.59.0