### PR TITLE
feat(sgapilinter): api-linter v2.0.0

### DIFF
--- a/tools/sgapilinter/tools.go
+++ b/tools/sgapilinter/tools.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	version = "1.69.2"
+	version = "2.0.0"
 	name    = "api-linter"
 )
 
@@ -62,7 +62,11 @@ func Run(ctx context.Context, args ...string) error {
 			case err != nil:
 				return err
 			case !d.IsDir() && filepath.Ext(path) == ".proto":
-				protoFiles = append(protoFiles, path)
+				relPath, err := filepath.Rel(moduleDir, path)
+				if err != nil {
+					return err
+				}
+				protoFiles = append(protoFiles, relPath)
 			}
 			return nil
 		}); err != nil {


### PR DESCRIPTION
This updates api-linter to version 2.0.0.

It is marked a breaking change in the repo but looking at the
[details](https://github.com/googleapis/api-linter/pull/1513) the
following reasons are stated:

1. Any functions or rule definitions that previously exposed types from
   the jhump/protoreflect library (e.g., desc.MessageDescriptor,
   desc.FieldDescriptor) now expose the official
   protoreflect.MessageDescriptor, protoreflect.FieldDescriptor, etc.
   types from google.golang.org/protobuf.
2. Consumers who use the api-linter as a library and have written custom
   rules will need to update their code to use the new protoreflect
   types.

The first one feels like very niche and not a general concern at
Einride. The second is not a valid use case for Sage which is not used
as a library so this breaking change feels acceptable.

Also as per https://github.com/googleapis/api-linter/pull/1545
api-linter can now correctly handle relative paths which solves some use
cases when proto files are spread across different places in a
repository so we switch to using relative paths to the buf.yaml rather
than aboslute.