### PR TITLE
feat: bump required go version to 1.24.9

### DIFF
--- a/.sage/go.mod
+++ b/.sage/go.mod
@@ -1,6 +1,6 @@
 module github.com/einride/sage/.sage
 
-go 1.22
+go 1.24.9
 
 require go.einride.tech/sage v0.0.0-00010101000000-000000000000
 

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module go.einride.tech/sage
 
-go 1.22
+go 1.24.9

--- a/tools/sggolicenses/tools.go
+++ b/tools/sggolicenses/tools.go
@@ -8,7 +8,6 @@ import (
 	"io/fs"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 
 	"go.einride.tech/sage/sg"
@@ -25,7 +24,7 @@ func Command(ctx context.Context, args ...string) *exec.Cmd {
 	return sg.Command(ctx, sg.FromBinDir(name), args...)
 }
 
-// Check for disallowed types of Go licenses in a specific directory.
+// CheckDir checks for disallowed types of Go licenses in a specific directory.
 // By default, Google's forbidden and restricted types are disallowed.
 func CheckDir(ctx context.Context, directory string, disallowedTypes ...string) error {
 	args := []string{
@@ -44,16 +43,6 @@ func CheckDir(ctx context.Context, directory string, disallowedTypes ...string) 
 	}
 	cmd := Command(ctx, args...)
 	cmd.Dir = directory
-	// go-licenses tries to exclude standard library packages by checking if they are prefixed
-	// with `runtime.GOROOT()`. However, if the go-licenses tool is not run with a GOROOT environment variable,
-	// that call will return the GOROOT path used during build time of go-licenses. This typically works on Linux,
-	// but on macOS with Homebrew, the GOROOT is version prefixed, which breaks as soon as Go is upgraded.
-	// For example: /opt/homebrew/Cellar/go/1.19.4/libexec
-	//
-	// As a workaround, add the GOROOT environment variable to the result of `runtime.GOROOT()` called here.
-	// This should work as the Sage binary is built on the same machine that executes it.
-	// See: https://github.com/google/go-licenses/issues/149
-	cmd.Env = append(cmd.Env, fmt.Sprintf("GOROOT=%s", runtime.GOROOT()))
 	return cmd.Run()
 }
 
@@ -88,16 +77,6 @@ func Check(ctx context.Context, disallowedTypes ...string) error {
 		}
 		cmd := Command(ctx, args...)
 		cmd.Dir = filepath.Dir(path)
-		// go-licenses tries to exclude standard library packages by checking if they are prefixed
-		// with `runtime.GOROOT()`. However, if the go-licenses tool is not run with a GOROOT environment variable,
-		// that call will return the GOROOT path used during build time of go-licenses. This typically works on Linux,
-		// but on macOS with Homebrew, the GOROOT is version prefixed, which breaks as soon as Go is upgraded.
-		// For example: /opt/homebrew/Cellar/go/1.19.4/libexec
-		//
-		// As a workaround, add the GOROOT environment variable to the result of `runtime.GOROOT()` called here.
-		// This should work as the Sage binary is built on the same machine that executes it.
-		// See: https://github.com/google/go-licenses/issues/149
-		cmd.Env = append(cmd.Env, fmt.Sprintf("GOROOT=%s", runtime.GOROOT()))
 		commands = append(commands, cmd)
 		return cmd.Start()
 	}); err != nil {


### PR DESCRIPTION
### Why?

- We should bump Go as we follow the same release policy as [Go's own release policy](https://go.dev/doc/devel/release#policy).
- We cannot upgrade certain dependencies, such as GoLicenses to its latest version.

```
[sggolicenses:prepare-command] go: github.com/google/go-licenses/v2@v2.0.1: github.com/google/go-licenses/v2@v2.0.1 requires go >= 1.23.0 (running go 1.22.12; GOTOOLCHAIN=local)
```


### What?

- Bump required Go version for Sage. Rather than bumping to 1.23, we are bumping to 1.24.
- Remove GOROOT (`GoLicenses` has been validated to still work as expected in one internal project):
  ```
	Error: tools/sggolicenses/tools.go:56:53: SA1019: runtime.GOROOT has been deprecated since Go 1.24: The root used during the Go build will not be meaningful if the binary is copied to another machine. Use the system path to locate the “go” binary, and use “go env GOROOT” to find its GOROOT. (staticcheck)
	cmd.Env = append(cmd.Env, fmt.Sprintf("GOROOT=%s", runtime.GOROOT()))
  ```