### PR TITLE
feat(sggh): bump GH CLI version to 2.83.1

### DIFF
--- a/tools/sggh/tools.go
+++ b/tools/sggh/tools.go
@@ -13,7 +13,7 @@ import (
 
 const (
 	name    = "gh"
-	version = "2.67.0"
+	version = "2.83.1"
 )
 
 func Command(ctx context.Context, args ...string) *exec.Cmd {


### PR DESCRIPTION
https://github.com/cli/cli/releases/tag/v2.83.1

I intend to use the fix of https://github.com/cli/cli/pull/11835 that was merged in 2.82.0.