### PR TITLE
docs: add link and badge to deepwiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,12 @@
 Sage is a Make-like build tool inspired by [Mage](https://magefile.org/) that
 provides a curated and maintained set of build [tools](./tools) for Go projects.
 
+For a detailed and AI-generated documentation on the architecture behind this
+project, which you can chat with, see the
+[DeepWiki documentation](https://deepwiki.com/einride/sage).
+
 [![Release](https://github.com/einride/sage/actions/workflows/release.yml/badge.svg)](https://github.com/einride/sage/actions/workflows/release.yml)
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/einride/sage)
 
 ## Requirements
 


### PR DESCRIPTION
Adds link to deep wiki-generated docs (pretty impressive).
By adding a badge, the documentation gets regenerated and kept up to date.

See preview page [here](https://github.com/einride/sage/blob/deepwiki/link/README.md).