### PR TITLE
fix(sgcloudspanner): bump emulator to 1.5.45

### DIFF
--- a/tools/sgcloudspanner/emulator.go
+++ b/tools/sgcloudspanner/emulator.go
@@ -17,7 +17,7 @@ import (
 // https://console.cloud.google.com/gcr/images/cloud-spanner-emulator/global/emulator
 const (
 	url     = "gcr.io/cloud-spanner-emulator/emulator"
-	version = "1.5.29"
+	version = "1.5.45"
 	image   = url + ":" + version
 )
 


### PR DESCRIPTION
same emulator bump in spanner-aip-go: https://github.com/einride/spanner-aip-go/pull/589