### PR TITLE
feat(example): use golangci-lint v2 for new repositories

### DIFF
--- a/example/.sage/main.go
+++ b/example/.sage/main.go
@@ -8,9 +8,8 @@ import (
 	"go.einride.tech/sage/tools/sgconvco"
 	"go.einride.tech/sage/tools/sggit"
 	"go.einride.tech/sage/tools/sggo"
-	"go.einride.tech/sage/tools/sggolangcilint"
+	"go.einride.tech/sage/tools/sggolangcilintv2"
 	"go.einride.tech/sage/tools/sggolicenses"
-	"go.einride.tech/sage/tools/sggolines"
 	"go.einride.tech/sage/tools/sgmdformat"
 	"go.einride.tech/sage/tools/sgyamlfmt"
 )
@@ -46,17 +45,17 @@ func GoTest(ctx context.Context) error {
 
 func GoLint(ctx context.Context) error {
 	sg.Logger(ctx).Println("linting Go files...")
-	return sggolangcilint.Run(ctx)
+	return sggolangcilintv2.Run(ctx, sggolangcilintv2.Config{})
 }
 
 func GoLintFix(ctx context.Context) error {
 	sg.Logger(ctx).Println("fixing Go files...")
-	return sggolangcilint.Fix(ctx)
+	return sggolangcilintv2.Fix(ctx, sggolangcilintv2.Config{})
 }
 
 func GoFormat(ctx context.Context) error {
 	sg.Logger(ctx).Println("formatting Go files...")
-	return sggolines.Run(ctx)
+	return sggolangcilintv2.Fmt(ctx, sggolangcilintv2.Config{})
 }
 
 func GoLicenses(ctx context.Context) error {


### PR DESCRIPTION
## Summary

- Migrate the example sagefile template from golangci-lint v1 to v2
- Remove `sggolines` dependency (v2 includes golines as a built-in formatter)
- Update `GoFormat` to use `sggolangcilintv2.Fmt()` for consistent formatting

## Why

New repositories initialized with `sage init` should use the latest golangci-lint v2 which provides:

- Built-in formatting support (gci, goimports, gofumpt, golines)
- Updated linter configurations with modern defaults
- Template-based config with exclusion path support

## Test plan

- [x] Ran `make` in sage root - all tests pass, linting shows 0 issues
- [x] Verified `go build` succeeds for the example sagefile