### PR TITLE
fix(sgtool): wrap the url with quotes so that the colon after it is not included in the url in GH ci

### DIFF
--- a/sgtool/file.go
+++ b/sgtool/file.go
@@ -250,10 +250,10 @@ func (s *fileState) downloadBinary(ctx context.Context, url string) (io.ReadClos
 	//nolint:bodyclose // false positive due to cleanup function
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
-		return nil, func() {}, fmt.Errorf("download binary %s: %w", url, err)
+		return nil, func() {}, fmt.Errorf("download binary %q: %w", url, err)
 	}
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
-		return nil, func() {}, fmt.Errorf("download binary %s: status code %d", url, resp.StatusCode)
+		return nil, func() {}, fmt.Errorf("download binary %q: status code %d", url, resp.StatusCode)
 	}
 	return resp.Body, func() { resp.Body.Close() }, nil
 }


### PR DESCRIPTION
Currently in some cases in GH CI the colon after the url is included in the url meaning the link when clicked lead nowhere. Since the %q wraps it double quotes, and double quotes not being valid url chars it should force the url to be formatted correctly.

Before (the url includes the colon after it in the link) : 
<img width="876" height="49" alt="Screenshot 2025-12-11 at 16 34 48" src="https://github.com/user-attachments/assets/0aee1577-999e-46ac-b28d-10a327d5c450" />

After:
<img width="701" height="45" alt="Screenshot 2025-12-11 at 16 37 43" src="https://github.com/user-attachments/assets/0bb36ff1-7a57-4bdb-9410-803a575a18f1" />
