### PR TITLE
fix(sg): strip .funcN closure suffix from target display name

### DIFF
--- a/sg/fn.go
+++ b/sg/fn.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"reflect"
 	"runtime"
+	"strconv"
 	"strings"
 )
 
@@ -86,6 +87,13 @@ func newFn(f any, args ...any) (Target, error) {
 	// suffix can simply be removed.
 	// See: https://stackoverflow.com/questions/32925344/why-is-there-a-fm-suffix-when-getting-a-functions-name-in-go
 	trimmedName := strings.TrimSuffix(name, "-fm")
+	// Strip anonymous function/closure suffix (.funcN) appended by the
+	// Go runtime. These are not meaningful display names.
+	if i := strings.LastIndex(trimmedName, ".func"); i != -1 {
+		if _, err := strconv.Atoi(trimmedName[i+5:]); err == nil {
+			trimmedName = trimmedName[:i]
+		}
+	}
 	return fn{
 		name: trimmedName,
 		id:   name + "(" + string(argsID) + ")",

--- a/sg/fn_test.go
+++ b/sg/fn_test.go
@@ -20,7 +20,7 @@ func TestFn_Name(t *testing.T) {
 		{
 			name:     "anonymous",
 			fn:       func(_ context.Context) error { return nil },
-			expected: "go.einride.tech/sage/sg.TestFn_Name.func1",
+			expected: "go.einride.tech/sage/sg.TestFn_Name",
 		},
 		{
 			name:     "namespace",


### PR DESCRIPTION
### Why?

```sh
❯ make go-lint
[sage] building binary and generating Makefiles...
[go-lint] linting Go files...
[sggolangcilintv-2:command:func-1] Using default relative path mode: gitroot
```

Note the `func-1`.

When closures are passed to `sg.Deps`, Go's `runtime.FuncForPC` appends `.funcN` to the enclosing function name. This suffix flows through `NewLogger`, producing noisy log prefixes like `[sggolangcilintv-2:command:func-1]` instead of `[sggolangcilintv-2:command]`.

cc @radhus - who also noticed this  😄 

### What?

- Strip trailing `.funcN` suffix from `fn.Name()` display name in `sg/fn.go`,
  analogous to the existing `-fm` method value suffix stripping

### Notes
- The unique `fn.ID()` retains the full runtime name for correct deduplication