### PR TITLE
chore: bump protoc-gen-go-aip-test to 0.38.0

### DIFF
--- a/tools/sgprotocgengoaiptest/tools.go
+++ b/tools/sgprotocgengoaiptest/tools.go
@@ -13,7 +13,8 @@ import (
 )
 
 const (
-	version = "0.37.0"
+	// renovate: datasource=github-releases depName=einride/protoc-gen-go-aip-test
+	version = "0.38.0"
 	name    = "protoc-gen-go-aip-test"
 )
 


### PR DESCRIPTION
Bump the hardcoded protoc-gen-go-aip-test version to get https://github.com/einride/protoc-gen-go-aip-test/pull/319