### PR TITLE
Add rumdl as markdown formatter

### DIFF
--- a/.sage/main.go
+++ b/.sage/main.go
@@ -10,7 +10,7 @@ import (
 	"go.einride.tech/sage/tools/sggo"
 	"go.einride.tech/sage/tools/sggolangcilintv2"
 	"go.einride.tech/sage/tools/sggolicenses"
-	"go.einride.tech/sage/tools/sgmdformat"
+	"go.einride.tech/sage/tools/sgrumdl"
 	"go.einride.tech/sage/tools/sgyamlfmt"
 )
 
@@ -71,7 +71,7 @@ func GoLicenses(ctx context.Context) error {
 
 func FormatMarkdown(ctx context.Context) error {
 	sg.Logger(ctx).Println("formatting Markdown files...")
-	return sgmdformat.Command(ctx).Run()
+	return sgrumdl.Command(ctx).Run()
 }
 
 func FormatYaml(ctx context.Context) error {

--- a/tools/sgrumdl/rumdl.toml
+++ b/tools/sgrumdl/rumdl.toml
@@ -1,0 +1,19 @@
+# rumdl configuration.
+# Docs: https://rumdl.dev/configuration/
+
+[global]
+# MD034 wraps bare URLs and emails in angle brackets (<...>) on fix. Disable it
+# to leave them untouched. https://rumdl.dev/md034/
+#
+# MD036 rewrites any emphasis-only paragraph (e.g. **Example: Something**) into
+# a level-2 heading. Bold lead-in labels are legitimate prose, so disable it to
+# avoid mangling them. https://rumdl.dev/md036/
+disable = ["MD034", "MD036"]
+
+# MD013 keeps lines short for better readability by enforcing a maximum line
+# length. https://rumdl.dev/md013/
+[MD013]
+# Maximum number of characters allowed per line.
+line-length = 80
+# Enable automatic reflow, wrapping long lines to fit within line-length.
+reflow = true

--- a/tools/sgrumdl/tools.go
+++ b/tools/sgrumdl/tools.go
@@ -1,0 +1,89 @@
+package sgrumdl
+
+import (
+	"context"
+	_ "embed"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+
+	"go.einride.tech/sage/sg"
+	"go.einride.tech/sage/sgtool"
+)
+
+const (
+	name = "rumdl"
+
+	// renovate: datasource=github-releases depName=rvben/rumdl
+	version = "0.2.22"
+)
+
+//go:embed rumdl.toml
+var config []byte
+
+func Command(ctx context.Context, args ...string) *exec.Cmd {
+	sg.Deps(ctx, PrepareCommand)
+	args = setDefaultArgs(args)
+	return sg.Command(ctx, sg.FromBinDir(name), args...)
+}
+
+// setDefaultArgs to format the repository using the bundled config. rumdl
+// formats the current directory recursively and respects .gitignore.
+func setDefaultArgs(args []string) []string {
+	if len(args) != 0 {
+		return args
+	}
+	return []string{"fmt", "--config", configPath(), "."}
+}
+
+func configPath() string {
+	return sg.FromToolsDir(name, "rumdl.toml")
+}
+
+func PrepareCommand(ctx context.Context) error {
+	toolDir := sg.FromToolsDir(name, version)
+	binary := filepath.Join(toolDir, name)
+	arch := runtime.GOARCH
+	switch arch {
+	case sgtool.AMD64:
+		arch = sgtool.X8664
+	case sgtool.ARM64:
+		arch = "aarch64"
+	}
+	target := fmt.Sprintf("%s-unknown-linux-gnu", arch)
+	if runtime.GOOS == sgtool.Darwin {
+		target = fmt.Sprintf("%s-apple-darwin", arch)
+	}
+	binURL := fmt.Sprintf(
+		"https://github.com/rvben/rumdl/releases/download/v%s/rumdl-v%s-%s.tar.gz",
+		version,
+		version,
+		target,
+	)
+	if err := sgtool.FromRemote(
+		ctx,
+		binURL,
+		sgtool.WithDestinationDir(toolDir),
+		sgtool.WithUntarGz(),
+		sgtool.WithSkipIfFileExists(binary),
+		sgtool.WithSymlink(binary),
+	); err != nil {
+		return fmt.Errorf("unable to download %s: %w", name, err)
+	}
+	if err := writeConfig(); err != nil {
+		return fmt.Errorf("unable to write %s config: %w", name, err)
+	}
+	return nil
+}
+
+// writeConfig writes the bundled config to the tools directory so it can be
+// passed to rumdl with the --config flag.
+func writeConfig() error {
+	path := configPath()
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, config, 0o600)
+}


### PR DESCRIPTION
### Why?

- I came across this nice no-dependency and single-binary markdown formatter: https://github.com/rvben/rumdl
- It is a lot faster and much nicer and easier to set up (than e.g. `mdformat` or `prettier`) in your local editor for when hitting save.

### What?

- Add `sgrumdl` as sage tool, including a toml configuration
- Use rumdl as formatting in this repo

### Notes

- The addition of `text` in the code fences, to denote the language type, can be disabled by disabling the `MD040` rule: https://rumdl.dev/md040
