### PR TITLE
feat(sguv): bump uv to 0.11.24 and add renovate annotation

### DIFF
--- a/tools/sguv/command.go
+++ b/tools/sguv/command.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	name    = "uv"
-	version = "0.10.3"
+	name = "uv"
+	// renovate: datasource=github-releases depName=astral-sh/uv
+	version = "0.11.24"
 
 	// Runtime OS constants.
 	windows = "windows"


### PR DESCRIPTION
## Why?

- The `sguv` tool is kind of old .. and does not get updated by renovate.

## What?

- Add a renovate annotation
- Bump uv to the latest `0.11.24`
