### PR TITLE
fix(sggovulncheck): bump golang.org/x/vuln to v1.5.0

### DIFF
--- a/tools/sggovulncheck/tools.go
+++ b/tools/sggovulncheck/tools.go
@@ -16,7 +16,7 @@ const (
 	name = "govulncheck"
 
 	// renovate: datasource=go depName=golang.org/x/vuln
-	version = "v1.4.0"
+	version = "v1.5.0"
 )
 
 // Command returns an [*exec.Cmd] for govulncheck.


### PR DESCRIPTION
## Summary

`sggovulncheck` pins `golang.org/x/vuln v1.4.0`, which vendors an older `golang.org/x/tools` that panics during callgraph analysis under go1.26:

```
panic: ForEachElement called on type containing *types.TypeParam
  golang.org/x/vuln@v1.4.0/internal/vulncheck/utils.go:72
```

This makes `go-vuln-check` crash in any downstream repo using a go1.26 toolchain on generics-heavy code.