### PR TITLE
fix: use `--ignore-scripts` flag for npm install

### DIFF
--- a/tools/sgcommitlint/tools.go
+++ b/tools/sgcommitlint/tools.go
@@ -73,7 +73,7 @@ func PrepareCommand(ctx context.Context) error {
 		toolDir,
 		"--no-save",
 		"--no-audit",
-		"--ignore-script",
+		"--ignore-scripts",
 	).Run(); err != nil {
 		return err
 	}

--- a/tools/sgcspevaluatorcli/tools.go
+++ b/tools/sgcspevaluatorcli/tools.go
@@ -44,7 +44,7 @@ func PrepareCommand(ctx context.Context) error {
 		toolDir,
 		"--no-save",
 		"--no-audit",
-		"--ignore-script",
+		"--ignore-scripts",
 	)
 	if err := cmd.Run(); err != nil {
 		return err

--- a/tools/sgnpmartifactregistryauth/tools.go
+++ b/tools/sgnpmartifactregistryauth/tools.go
@@ -44,7 +44,7 @@ func PrepareCommand(ctx context.Context) error {
 		toolsDir,
 		"--no-save",
 		"--no-audit",
-		"--ignore-script",
+		"--ignore-scripts",
 	).Run(); err != nil {
 		return err
 	}

--- a/tools/sgnpmlicense/tools.go
+++ b/tools/sgnpmlicense/tools.go
@@ -273,7 +273,7 @@ func PrepareCommand(ctx context.Context) error {
 		toolDir,
 		"--no-save",
 		"--no-audit",
-		"--ignore-script",
+		"--ignore-scripts",
 	).Run(); err != nil {
 		return err
 	}

--- a/tools/sgprettier/tools.go
+++ b/tools/sgprettier/tools.go
@@ -91,7 +91,7 @@ func PrepareCommand(ctx context.Context) error {
 		toolDir,
 		"--no-save",
 		"--no-audit",
-		"--ignore-script",
+		"--ignore-scripts",
 	).Run(); err != nil {
 		return err
 	}

--- a/tools/sgsemanticrelease/tools.go
+++ b/tools/sgsemanticrelease/tools.go
@@ -90,7 +90,7 @@ func PrepareCommand(ctx context.Context, branch string) error {
 		toolDir,
 		"--no-save",
 		"--no-audit",
-		"--ignore-script",
+		"--ignore-scripts",
 	).Run(); err != nil {
 		return err
 	}


### PR DESCRIPTION
npm 12 no longer accepts the singular `--ignore-script` alias.