### PR TITLE
chore(sggolangcilint): mark as deprecated

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -1,3 +1,6 @@
+// Package sggolangcilint provides golangci-lint v1 tooling.
+//
+// Deprecated: use go.einride.tech/sage/tools/sggolangcilintv2 instead.
 package sggolangcilint
 
 import (


### PR DESCRIPTION
## Why?

- [`sggolangcilintv2`](https://github.com/einride/sage/tree/master/tools/sggolangcilintv2) supersedes the golangci-lint v1 wrapper.
- Deprecating at the package level only keeps a single pointer to v2, so per-function "use X instead" notices cannot drift as the v2 API evolves.

## What?

- Add a `Deprecated:` package comment to [`sggolangcilint`](https://github.com/einride/sage/tree/master/tools/sggolangcilint) pointing to `sggolangcilintv2`.

## Notes

- Staticcheck ([SA1019](https://staticcheck.dev/docs/checks#SA1019)) reports a package-level deprecation once, at the import statement, rather than at each call site — enough to flag consumers still on v1.