### PR TITLE
feat: add sgwiz tool

### DIFF
--- a/tools/sgwiz/tools.go
+++ b/tools/sgwiz/tools.go
@@ -1,0 +1,211 @@
+// Package sgwiz provides commands for the Wiz CLI.
+//
+// Authentication differs between environments: in a CI pipeline the CLI authenticates with a
+// service account, using the WIZ_CLIENT_ID and WIZ_CLIENT_SECRET environment variables, while
+// locally it authenticates the developer through the device code flow. The scan commands in this
+// package pick the right one, so no separate authentication step is needed. See [Authenticate].
+package sgwiz
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+
+	"go.einride.tech/sage/sg"
+	"go.einride.tech/sage/sgtool"
+)
+
+const (
+	// The Wiz CLI is distributed from downloads.wiz.io, which has no Renovate datasource,
+	// so this version must be bumped manually.
+
+	version = "1.70.0"
+	name    = "wizcli"
+
+	downloadURL = "https://downloads.wiz.io/v1/wizcli"
+)
+
+// Authenticate authenticates the Wiz CLI, caching a token for subsequent scans.
+//
+// The scan commands in this package authenticate on their own, so this is only needed to
+// authenticate up front – locally, to get the browser-based device code flow out of the way
+// before scanning.
+//
+// In a CI pipeline, it authenticates with the service account credentials in the WIZ_CLIENT_ID
+// and WIZ_CLIENT_SECRET environment variables.
+func Authenticate(ctx context.Context) error {
+	if isCI() {
+		// The Wiz CLI reads the client ID and secret from the environment.
+		for _, key := range []string{"WIZ_CLIENT_ID", "WIZ_CLIENT_SECRET"} {
+			if os.Getenv(key) == "" {
+				return fmt.Errorf("%s must be set to authenticate %s in a CI pipeline", key, name)
+			}
+		}
+	}
+	args := append([]string{"auth"}, commonArgs()...)
+	return Command(ctx, args...).Run()
+}
+
+// ScanDirCommand returns a command that scans dir.
+//
+// A directory scan covers vulnerabilities, secrets, sensitive data, infrastructure as code
+// misconfigurations, software supply chain risks, AI models, SAST weaknesses and malware. Pass
+// --disabled-scanners to opt out of any of them.
+func ScanDirCommand(ctx context.Context, dir string) *exec.Cmd {
+	args := append([]string{"scan", "dir", dir}, scanArgs()...)
+	return Command(ctx, args...)
+}
+
+// ScanContainerImageCommand returns a command that scans a container image, given by name
+// including its tag or digest, or by path to a tarball.
+func ScanContainerImageCommand(ctx context.Context, image string) *exec.Cmd {
+	args := append([]string{"scan", "container-image", image}, scanArgs()...)
+	return Command(ctx, args...)
+}
+
+// Command returns a command for the Wiz CLI with the given arguments.
+//
+// Unlike the scan commands in this package, it applies no default arguments and does not
+// authenticate. Use it for subcommands this package doesn't cover, or to opt out of the defaults.
+func Command(ctx context.Context, args ...string) *exec.Cmd {
+	sg.Deps(ctx, PrepareCommand)
+	return sg.Command(ctx, sg.FromBinDir(name), args...)
+}
+
+// PrepareCommand downloads and installs the Wiz CLI, verifying the download against the SHA256
+// checksum published alongside it. See [verifyChecksum].
+//
+// A successful verification is recorded next to the binary, so an already installed Wiz CLI is
+// neither re-downloaded nor re-verified. The install directory is version scoped, so bumping
+// [version] always installs and verifies afresh.
+func PrepareCommand(ctx context.Context) error {
+	switch runtime.GOOS {
+	case "linux", sgtool.Darwin:
+	default:
+		return fmt.Errorf("unsupported OS in sgwiz package: %s", runtime.GOOS)
+	}
+	switch runtime.GOARCH {
+	case sgtool.AMD64, sgtool.ARM64:
+	default:
+		return fmt.Errorf("unsupported ARCH in sgwiz package: %s", runtime.GOARCH)
+	}
+	toolDir := sg.FromToolsDir(name, version)
+	binary := filepath.Join(toolDir, name)
+	verified := binary + ".verified"
+	if _, err := os.Stat(verified); err == nil {
+		_, err := sgtool.CreateSymlink(binary)
+		return err
+	}
+	// A gzipped binary is also published, at a third of the size, but only for the latest
+	// version and not for the pinned versions this package downloads.
+	binURL := fmt.Sprintf("%s/%s/%s-%s-%s", downloadURL, version, name, runtime.GOOS, runtime.GOARCH)
+	// The binary is deliberately not symlinked until it has been verified.
+	if err := sgtool.FromRemote(
+		ctx,
+		binURL,
+		sgtool.WithDestinationDir(toolDir),
+		sgtool.WithRenameFile("", name),
+	); err != nil {
+		return fmt.Errorf("unable to download %s: %w", name, err)
+	}
+	if err := os.Chmod(binary, 0o755); err != nil {
+		return fmt.Errorf("unable to make %s command: %w", name, err)
+	}
+	checksumFile := binary + "-sha256"
+	if err := sgtool.FromRemote(
+		ctx,
+		binURL+"-sha256",
+		sgtool.WithDestinationDir(toolDir),
+		sgtool.WithRenameFile("", filepath.Base(checksumFile)),
+	); err != nil {
+		return fmt.Errorf("unable to download the %s checksum: %w", name, err)
+	}
+	if err := verifyChecksum(ctx, binary, checksumFile); err != nil {
+		// Remove the binary, so that a tampered with or truncated download can neither be
+		// run nor be treated as installed by a later invocation.
+		if removeErr := os.Remove(binary); removeErr != nil {
+			return fmt.Errorf("%w (unable to remove %s: %v)", err, binary, removeErr)
+		}
+		return err
+	}
+	if err := os.WriteFile(verified, []byte(version), 0o600); err != nil {
+		return err
+	}
+	_, err := sgtool.CreateSymlink(binary)
+	return err
+}
+
+// verifyChecksum verifies the binary against the SHA256 checksum published alongside it.
+//
+// This detects a corrupted or truncated download. Note that it does not establish that Wiz
+// published the binary, as the checksum is served from the same host, over the same channel, as
+// the binary itself. Wiz also publishes an OpenPGP signature of the checksum, which would
+// establish that, but verifying it requires gpg and is deliberately not done here.
+func verifyChecksum(ctx context.Context, binary, checksumFile string) error {
+	content, err := os.ReadFile(checksumFile)
+	if err != nil {
+		return err
+	}
+	// The published checksum file holds a bare hex digest, with no trailing newline or filename.
+	expected := strings.ToLower(strings.TrimSpace(string(content)))
+	if len(expected) != hex.EncodedLen(sha256.Size) {
+		return fmt.Errorf("unexpected %s checksum %q", name, expected)
+	}
+	file, err := os.Open(binary)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+	digest := sha256.New()
+	if _, err := io.Copy(digest, file); err != nil {
+		return err
+	}
+	if actual := hex.EncodeToString(digest.Sum(nil)); actual != expected {
+		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", binary, expected, actual)
+	}
+	sg.Logger(ctx).Printf("verified %s checksum", name)
+	return nil
+}
+
+// scanArgs returns the arguments applied to all scan commands in this package.
+func scanArgs() []string {
+	var args []string
+	if !isCI() {
+		// Authenticate the developer rather than a service account. In a CI pipeline the client
+		// ID and secret are picked up from the environment instead.
+		args = append(args, "--use-device-code")
+	}
+	// Keep scan results local instead of publishing them to the Wiz portal.
+	args = append(args, "--no-publish")
+	return append(args, commonArgs()...)
+}
+
+// commonArgs returns arguments applied to every Wiz CLI command in this package.
+func commonArgs() []string {
+	if !isCI() {
+		return nil
+	}
+	// Styled output is unreadable in CI logs, which have no terminal.
+	return []string{"--no-color", "--no-style"}
+}
+
+// isCI reports whether we are running in a CI pipeline.
+func isCI() bool {
+	for _, key := range []string{"CI", "GITHUB_ACTIONS"} {
+		// CI systems commonly set these to "true" or "1", but treat any other non-empty
+		// value as an indication that we are running in a pipeline.
+		switch os.Getenv(key) {
+		case "", "false", "0":
+		default:
+			return true
+		}
+	}
+	return false
+}

--- a/tools/sgwiz/tools_test.go
+++ b/tools/sgwiz/tools_test.go
@@ -1,0 +1,109 @@
+package sgwiz
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+)
+
+func TestVerifyChecksum(t *testing.T) {
+	// echo -n "wizcli" | shasum -a 256
+	const (
+		content  = "wizcli"
+		checksum = "fcaedabad6acbd6c4278824799b267faae2c87ad7e96b1fdd3ce4af7fa042a95"
+	)
+	write := func(t *testing.T, binaryContent, checksumContent string) (string, string) {
+		t.Helper()
+		dir := t.TempDir()
+		binary := filepath.Join(dir, name)
+		checksumFile := binary + "-sha256"
+		if err := os.WriteFile(binary, []byte(binaryContent), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(checksumFile, []byte(checksumContent), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return binary, checksumFile
+	}
+	t.Run("mismatch is rejected", func(t *testing.T) {
+		binary, checksumFile := write(t, "tampered with", checksum)
+		if err := verifyChecksum(context.Background(), binary, checksumFile); err == nil {
+			t.Error("verifyChecksum() = nil, expected a checksum mismatch")
+		}
+	})
+	t.Run("truncated binary is rejected", func(t *testing.T) {
+		binary, checksumFile := write(t, content[:3], checksum)
+		if err := verifyChecksum(context.Background(), binary, checksumFile); err == nil {
+			t.Error("verifyChecksum() = nil, expected a checksum mismatch")
+		}
+	})
+	t.Run("malformed checksum is rejected", func(t *testing.T) {
+		binary, checksumFile := write(t, content, "not-a-checksum")
+		if err := verifyChecksum(context.Background(), binary, checksumFile); err == nil {
+			t.Error("verifyChecksum() = nil, expected a malformed checksum error")
+		}
+	})
+	t.Run("trailing whitespace is tolerated", func(t *testing.T) {
+		binary, checksumFile := write(t, content, checksum+"\n")
+		if err := verifyChecksum(context.Background(), binary, checksumFile); err != nil {
+			t.Errorf("verifyChecksum() = %v, expected the checksum to match", err)
+		}
+	})
+}
+
+func TestIsCI(t *testing.T) {
+	for _, tt := range []struct {
+		name          string
+		ci            string
+		githubActions string
+		expected      bool
+	}{
+		{name: "unset", expected: false},
+		{name: "CI true", ci: "true", expected: true},
+		{name: "CI 1", ci: "1", expected: true},
+		{name: "CI false", ci: "false", expected: false},
+		{name: "CI empty", ci: "", expected: false},
+		{name: "GitHub Actions", githubActions: "true", expected: true},
+		{name: "CI disabled in GitHub Actions", ci: "false", githubActions: "true", expected: true},
+		{name: "non-boolean value", ci: "yes", expected: true},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("CI", tt.ci)
+			t.Setenv("GITHUB_ACTIONS", tt.githubActions)
+			if actual := isCI(); actual != tt.expected {
+				t.Errorf("isCI() = %v, expected %v", actual, tt.expected)
+			}
+		})
+	}
+}
+
+func TestScanArgs(t *testing.T) {
+	t.Run("locally", func(t *testing.T) {
+		t.Setenv("CI", "")
+		t.Setenv("GITHUB_ACTIONS", "")
+		actual := scanArgs()
+		for _, arg := range []string{"--use-device-code", "--no-publish"} {
+			if !slices.Contains(actual, arg) {
+				t.Errorf("scanArgs() = %v, expected it to contain %s", actual, arg)
+			}
+		}
+		if slices.Contains(actual, "--no-color") {
+			t.Errorf("scanArgs() = %v, expected it not to disable styled output locally", actual)
+		}
+	})
+	t.Run("in a CI pipeline", func(t *testing.T) {
+		t.Setenv("CI", "true")
+		actual := scanArgs()
+		for _, arg := range []string{"--no-publish", "--no-color", "--no-style"} {
+			if !slices.Contains(actual, arg) {
+				t.Errorf("scanArgs() = %v, expected it to contain %s", actual, arg)
+			}
+		}
+		// In CI the service account credentials are used, not the developer's own.
+		if slices.Contains(actual, "--use-device-code") {
+			t.Errorf("scanArgs() = %v, expected it not to use the device code flow in CI", actual)
+		}
+	})
+}


### PR DESCRIPTION
This PRs add a Sage tool for the Wiz CLI. Example usage:

```go
// WizAuth authenticates the Wiz CLI.
//
// Locally this opens a browser for the device code flow, and only needs to be run once — the
// Wiz CLI caches the token. In CI it is unnecessary: the scan targets authenticate themselves
// from WIZ_CLIENT_ID and WIZ_CLIENT_SECRET.
func WizAuth(ctx context.Context) error {
	sg.Logger(ctx).Println("authenticating the Wiz CLI...")
	return sgwiz.Authenticate(ctx)
}

// WizScan scans the repository for vulnerabilities, secrets and IaC misconfigurations.
//
// Run `make wiz-auth` once first when running locally.
func WizScan(ctx context.Context) error {
	sg.Logger(ctx).Println("scanning the repository with Wiz...")
	return sgwiz.ScanDirCommand(ctx, sg.FromGitRoot(".")).Run()
}
```