### PR TITLE
fix(sggolangcilintv2): skip dir instead of skip all on empty go.mod file

### DIFF
--- a/tools/sggolangcilintv2/tools.go
+++ b/tools/sggolangcilintv2/tools.go
@@ -100,9 +100,9 @@ func Run(ctx context.Context, config Config, args ...string) error {
 		if err != nil {
 			return err
 		}
-		// ignore if it's an empty go.mod
+		// ignore this directory and its sub-directories if it's an empty go.mod
 		if fileInfo.Size() == 0 {
-			return filepath.SkipAll
+			return filepath.SkipDir
 		}
 		cmd := CommandRunInDirectory(ctx, config, filepath.Dir(path), args...)
 		commands = append(commands, cmd)


### PR DESCRIPTION
When `SkipAll` is returned, all the directories after this one are skipped, meaning that the linting is aborted. Using `SkipDir` instead only skips the current directory and its sub-directories, but not the ones after it.

[Slack thread](https://einride.slack.com/archives/CA484JN22/p1788181356362579) with some background.