### PR TITLE
fix(sggolangcilintv2): don't prune sibling entries on empty go.mod

### DIFF
--- a/tools/sggolangcilintv2/tools.go
+++ b/tools/sggolangcilintv2/tools.go
@@ -100,9 +100,9 @@ func Run(ctx context.Context, config Config, args ...string) error {
 		if err != nil {
 			return err
 		}
-		// ignore this directory and its sub-directories if it's an empty go.mod
+		// ignore if it's an empty go.mod
 		if fileInfo.Size() == 0 {
-			return filepath.SkipDir
+			return nil
 		}
 		cmd := CommandRunInDirectory(ctx, config, filepath.Dir(path), args...)
 		commands = append(commands, cmd)


### PR DESCRIPTION
## Why?

- Follow-up to #867: [`filepath.SkipDir`](https://pkg.go.dev/path/filepath#SkipDir) returned while visiting a *file* does not skip that directory's subtree — per the [`io/fs.WalkDirFunc` docs](https://pkg.go.dev/io/fs#WalkDirFunc) it skips the remaining entries of the *parent* directory, and [`filepath.WalkDir`](https://pkg.go.dev/path/filepath#WalkDir) walks in lexical order.
- Result: which nested modules get linted depends on whether their directory name sorts before or after the string `go.mod`:

```
root/
├── api/
│   └── go.mod        <- linted ("api" < "go.mod", walked before SkipDir)
├── go.mod            <- empty, returns SkipDir
└── pkg/
    └── go.mod        <- silently skipped ("pkg" > "go.mod", never visited)
```

## What?

- Return `nil` instead of `filepath.SkipDir` on an empty `go.mod`, ignoring only that file — every other directory is still walked and its module linted, the same handling `Fix()` and `Fmt()` already use.

## Notes

- Verified with a minimal `WalkDir` reproduction of the layout above: `api` was linted, `pkg` was not; renaming `api` to `zapi` made zero modules lint.
