### PR TITLE
feat(sggolangcilintv2): upgrade golangci-lint to 2.13.2

### DIFF
--- a/tools/sggolangcilint/tools.go
+++ b/tools/sggolangcilint/tools.go
@@ -93,7 +93,8 @@ func Fix(ctx context.Context, args ...string) error {
 		}
 		cmd := Command(
 			ctx,
-			append([]string{"run", "--allow-serial-runners", "-c", defaultConfigPath(), "--fix"}, args...)...)
+			append([]string{"run", "--allow-serial-runners", "-c", defaultConfigPath(), "--fix"}, args...)...,
+		)
 		cmd.Dir = filepath.Dir(path)
 		commands = append(commands, cmd)
 		return cmd.Start()

--- a/tools/sggolangcilintv2/golangci.yml.tmpl
+++ b/tools/sggolangcilintv2/golangci.yml.tmpl
@@ -275,7 +275,10 @@ formatters:
 
   settings:
     gofumpt:
-      extra-rules: true
+      extra:
+        group-params: true
+        clothe-returns: true
+        balance-calls: true
     golines:
       max-len: 120
       reformat-tags: false

--- a/tools/sggolangcilintv2/tools.go
+++ b/tools/sggolangcilintv2/tools.go
@@ -22,7 +22,7 @@ const (
 	name = "golangci-lint"
 
 	// renovate: datasource=github-releases depName=golangci/golangci-lint
-	version = "2.12.2"
+	version = "2.13.2"
 
 	RunRelativePathModeGitRoot    = "gitroot"
 	RunRelativePathModeGomod      = "gomod"


### PR DESCRIPTION
## Why?

- [golangci-lint](https://github.com/golangci/golangci-lint) 2.12.2 is built with go1.26 and refuses modules targeting go1.27:

  ```
  can't load config: the Go language version (go1.26) used to build golangci-lint
  is lower than the targeted Go version (1.27.1)
  ```

- A `toolchain go1.27.1` directive in a consumer's go.mod is enough to trigger this; [2.13.0 added go1.27 support](https://golangci-lint.run/docs/product/changelog/#2130).

## What?

- Bump pinned golangci-lint 2.12.2 → 2.13.2.
- Migrate gofumpt config from deprecated `extra-rules` to the granular `extra.*` options (all enabled, identical behavior).
- Reformat one call site in `sggolangcilint` that the newer gofumpt flags.