### PR TITLE
feat(renovate): add dependencies label and force feat commit type for all updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,7 +4,7 @@
   "minimumReleaseAge": "3 days",
   "postUpdateOptions": ["gomodTidy"],
   "semanticCommits": "enabled",
-  "semanticCommitType": "feat",
+  "labels": ["dependencies"],
   "packageRules": [
     {
       "matchManagers": [
@@ -33,6 +33,11 @@
       "matchUpdateTypes": ["major", "minor"],
       "enabled": false,
       "description": "Disable major and minor Go version bumps for version consts (follow N-1 policy manually)"
+    },
+    {
+      "matchPackageNames": ["*"],
+      "semanticCommitType": "feat",
+      "description": "Override config:recommended's chore/fix split so all Renovate PRs use feat and trigger a release"
     }
   ],
   "customManagers": [


### PR DESCRIPTION
feat(renovate): add dependencies label and force feat commit type for all updates

Adding a "dependencies" label to all renovate PRs. This brings it in line with how dependabot works out of the box and allows for similar functionality such as filtering on all PRs with that label.

Also, "chore" does not trigger a release by default in most semantic release tooling and dependency changes are potential code changes so we switch from "chore" to "feat" instead.